### PR TITLE
Avoid adding duplicate wires

### DIFF
--- a/generic/simple.py
+++ b/generic/simple.py
@@ -16,14 +16,17 @@ if not device:
 with open(f"../{device}.pickle", 'rb') as f:
     db = pickle.load(f)
 
+
+added_wires = []
 def addWire(row, col, wire):
     gname = chipdb.wire2global(row, col, db, wire)
     #print("wire", gname)
-    try:
+    if gname in added_wires:
+        # print(f"Duplicate wire {gname}")
+        return
+    else:
+        added_wires.append(gname)
         ctx.addWire(name=gname, type=wire, y=row, x=col)
-    except AssertionError:
-        pass
-        #print("duplicate wire")
 
 belre = re.compile(r"(IOB|LUT|DFF|BANK|CFG)(\w*)")
 for row, rowdata in enumerate(db.grid, 1):


### PR DESCRIPTION
The current solution where exceptions are caught doesn't seem to work with newer versions of nextpnr. This issue is avoided by keeping track of added wires and not adding them at all instead.