### PR TITLE
Add github workflow to build and upload chipdb

### DIFF
--- a/.github/workflows/chipdb.yml
+++ b/.github/workflows/chipdb.yml
@@ -1,0 +1,22 @@
+name: Chipdb builder
+
+on:
+  push:
+    branches:
+        - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build chipdb
+      run: |
+        docker build . --file Dockerfile --tag apicula-chipdb
+        docker run --env DEVICE=GW1N-1  -v $(pwd)/apicula-chipdb:/artifacts --rm apicula-chipdb:latest
+        docker run --env DEVICE=GW1NR-9 -v $(pwd)/apicula-chipdb:/artifacts --rm apicula-chipdb:latest
+    - name: Archive artifact
+      uses: actions/upload-artifact@v2
+      with:
+          name: apicula-chipdb
+          path: apicula-chipdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,22 @@
 FROM python:3
 
 WORKDIR /usr/src/gowin
-ADD ["https://www.gowinsemi.com/upload/database_doc/359/document/5cf8eb7f250cf.xlsx", "/root/Documents/gowinsemi/GW1NR-9 Pinout.xlsx"]
-ADD ["https://www.gowinsemi.com/upload/database_doc/186/document/5e1ff868b7434.xlsx", "/root/Documents/gowinsemi/GW1N-1 Pinout.xlsx"]
-ADD http://cdn.gowinsemi.com.cn/Gowin_V1.9.3.01Beta_linux.tar.gz gowin.tgz
-RUN tar -xf gowin.tgz
-ENV GOWINHOME /usr/src/gowin
-RUN pip install --no-cache-dir numpy pandas pillow crcmod xlrd
+
+RUN apt-get update && apt-get install -y curl && \
+    pip install --no-cache-dir numpy pandas pillow crcmod xlrd && \
+    mkdir -p "/root/Documents/gowinsemi/" && \
+    curl -so "/root/Documents/gowinsemi/GW1NR-9 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG801-1.5E_GW1NR-9%20Pinout.xlsx" && \
+    curl -so "/root/Documents/gowinsemi/GW1N-1 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG107-1.09E_GW1N-1%20Pinout.xlsx" && \
+    curl -so gowin.tgz "http://cdn.gowinsemi.com.cn/Gowin_V1.9.3.01Beta_linux.tar.gz" && \
+    tar -xf gowin.tgz
 
 WORKDIR /usr/src/apicula
 COPY . .
 
-CMD python dat19_h4x.py; python tiled_fuzzer.py
+ENV GOWINHOME /usr/src/gowin
+ENV ARTIFACTS /artifacts
+
+CMD python dat19_h4x.py && \
+    python tiled_fuzzer.py && \
+    mkdir -p ${ARTIFACTS} && \
+    cp ${DEVICE}.json ${DEVICE}.pickle ${ARTIFACTS}


### PR DESCRIPTION
This will build the chipdb for each new commit to the master branch and upload it as a github artifact . Not sure if that is a bit redundant, but at least it runs automatically whenever stuff changes.

An example run of this can be seen in https://github.com/kbeckmann/apicula/actions/runs/193110067

The reason to why I changed `ADD` to `RUN curl..` is so that it gets cached. Docker will download the files every single time the container is built otherwise.