### PR TITLE
generic/simple.py: force wire type to be a string

### DIFF
--- a/generic/simple.py
+++ b/generic/simple.py
@@ -33,7 +33,7 @@ for row, rowdata in enumerate(db.grid, 1):
         # add wires
         wires = set(chain(tile.pips.keys(), *tile.pips.values()))
         for wire in wires:
-            addWire(row, col, wire)
+            addWire(row, col, str(wire))
         # add aliasses
         # creat bels
         #print(row, col, ttyp)
@@ -116,7 +116,7 @@ for row, rowdata in enumerate(db.grid, 1):
     for col, tile in enumerate(rowdata, 1):
         for dest, srcs in tile.pips.items():
             for src in srcs.keys():
-                addPip(row, col, src, dest)
+                addPip(row, col, str(src), str(dest))
         for dest, src in tile.aliases.items():
             addAlias(row, col, src, dest)
 


### PR DESCRIPTION
Some wire name are composed only to digit ( for instance `1007`).
python, in this case, uses a `int` type instead of `string`. The consequences are failure in some call
for instance in:
```
def wire2global(row, col, db, wire):
    if wire.startswith("G") or wire in {'VCC', 'VSS'}:
```
where `int` as no `startwith`