### PR TITLE
Fix CRC check and errors when using python 3.8.5

### DIFF
--- a/apycula/gowin_bba.py
+++ b/apycula/gowin_bba.py
@@ -1,10 +1,13 @@
+#!/usr/bin/env python3
 import sys
+import os
 import importlib.resources
 import pickle
 import argparse
 import re
 from contextlib import contextmanager
 from collections import Counter
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 from apycula import chipdb
 
 class Bba(object):

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -5,7 +6,7 @@ import pickle
 import numpy as np
 import json
 import argparse
-import importlib.resources
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 from apycula import chipdb
 from apycula import bslib
 from apycula.wirenames import wirenames, wirenumbers
@@ -27,6 +28,8 @@ def get_pips(data):
             if res:
                 row, col, src, dest = res.groups()
                 yield int(row), int(col), src, dest
+            elif "ALIAS" in pip:
+                print("Ignoring alias:", pip)
             elif pip:
                 print("Invalid pip:", pip)
 
@@ -108,7 +111,7 @@ def header_footer(db, bs):
     CRC_check and security_bit_enable set
     """
     bs = np.fliplr(bs)
-    bs=np.packbits(bs, axis=1)
+    bs = np.packbits(bs)
     # configuration data checksum is computed on all
     # data in 16bit format
     bb = np.array(bs.flat)
@@ -129,7 +132,7 @@ def main():
 
     args = parser.parse_args()
 
-    with importlib.resources.open_binary("apycula", f"{args.device}.pickle") as f:
+    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), f"{args.device}.pickle"), "rb") as f:
         db = pickle.load(f)
     with open(args.netlist) as f:
         pnr = json.load(f)

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 import re
@@ -7,6 +8,7 @@ from itertools import chain, count
 import pickle
 import argparse
 import importlib.resources
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 from apycula import codegen
 from apycula import chipdb
 from apycula.bslib import read_bitstream


### PR DESCRIPTION
I had to make the following changes to remove problems on my system Ubuntu 20.04.1 LTS:

 - set axis argument to None/default in np.packbits
 - remove usage of importlib.resources
 - make gowin_* files executable
 - add parent to path to import from apycula

With these changes I can compile nextpnr-gowin, make this project, and also openFPGALoad does not complain about CRC failures anymore.

```sh
# tested with:
cd apicula/examples/
make
nextpnr-gowin --json blinky.json --write pnrblinky.json --device GW1NR-LV9QN881C6/I5 --cst tec0117.cst
../apycula/gowin_pack.py -d GW1N-9 -o blinky.fs pnrblinky.json
openFPGALoader -b littleBee -m blinky.fs
#openFPGALoader -b littleBee -r -f blinky.fs
```