### PR TITLE
fix crc check fail when using python 3.8.5

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -108,10 +108,10 @@ def header_footer(db, bs):
     CRC_check and security_bit_enable set
     """
     bs = np.fliplr(bs)
-    bs=np.packbits(bs, axis=1)
+    bs=np.packbits(bs)
     # configuration data checksum is computed on all
     # data in 16bit format
-    bb = np.array(bs.flat)
+    bb = np.array(bs)
 
     res = int(bb[0::2].sum() * pow(2,8) + bb[1::2].sum())
     checksum = res & 0xffff


### PR DESCRIPTION
 - set axis argument to None/default in np.packbits
 
With this patch I do not see `CRC check : FAIL` anymore when flashing with openFPGALoad. Tested with:

```sh
cd examples/
rm -rf *.json
make
nextpnr-gowin --json blinky.json --write pnrblinky.json --device GW1NR-LV9QN881C6/I5 --cst tec0117.cst
gowin_pack -d GW1N-9 -o blinky.fs pnrblinky.json
openFPGALoader -b littleBee -r -f blinky.fs 
```