### PR TITLE
Update build steps in Makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,26 @@
-all: attosoc.json blinky.json
+DEVICE ?= GW1N-9
+PN ?= GW1NR-UV9QN881C6/I5
+BOARD ?= tec0117
+
+all: attosoc.fs blinky.fs
+
+%.fs: %.pnr.json
+	gowin_pack -d ${DEVICE} -o $@ $^
+	cp $@ ${BOARD}-$@
+
+%.pnr.json: %.json
+	nextpnr-gowin --json $^ --write $@ --device ${PN} --cst ${BOARD}.cst
 
 attosoc.json: attosoc/attosoc.v attosoc/picorv32.v
 	yosys -p "synth_gowin -json $@" $^
 
 %.json: %.v
 	yosys -p "synth_gowin -json $@" $^
+
+prog:
+	openFPGALoader -b littleBee -r -f blinky.fs
+
+clean:
+	rm -f *.json *.fs
+
+.PHONY: prog clean


### PR DESCRIPTION
 - add steps to build all fs files by default
 - add clean
 - add prog to program blinky

This change enables to run blinky test on TEC0117 with:
```sh
make clean
make
make prog
```