### PR TITLE
readme, examples/Makefile: fix openFPGALoader target board name

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -25,10 +25,10 @@ attosoc.json: attosoc/attosoc.v attosoc/picorv32.v
 	yosys -p "synth_gowin -json $@" $^
 
 %-tec0117-prog: %-tec0117.fs
-	openFPGALoader -b littleBee $^
+	openFPGALoader -b tec0117 $^
 
 %-runber-prog: %-runber.fs
-	openFPGALoader -b littleBee -c ft232 $^
+	openFPGALoader -b runber $^
 
 %-tangnano-prog: %-tangnano.fs
 	openFPGALoader -b tangnano $^

--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,8 @@ nextpnr-gowin --json blinky.json \
 gowin_pack -d GW1N-9 -o pack.fs pnrblinky.json
 # gowin_unpack -d GW1N-9 -o unpack.v pack.fs
 # yosys -p "read_verilog -lib +/gowin/cells_sim.v; clean -purge; show" unpack.v
-openFPGALoader -b littleBee pack.fs # TEC0117
-openFPGALoader -b littleBee -c ft232 pack.fs # RUNBER
+openFPGALoader -b tec0117 pack.fs # TEC0117
+openFPGALoader -b runber pack.fs # RUNBER
 openFPGALoader -b tangnano pack.fs # Tang Nano
 ```
 


### PR DESCRIPTION
Flash instruction and Makefile rules update:
- instead of using the ambiguous *littleBee* name a new entry *tec0117* has been added
- seeestudio runber is now officially supported