### PR TITLE
examples: fix the number of leds according to the targeted board

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,31 +1,36 @@
+runber_leds=8
+tangnano_leds=3
+tec0117_leds=8
+
 all: attosoc-tec0117.fs blinky-tec0117.fs blinky-runber.fs blinky-tangnano.fs
 
 %-tec0117.fs: %-tec0117.json
 	gowin_pack -d GW1N-9 -o $@ $^
 
-%-tec0117.json: %.json
+%-tec0117.json: %-tec0117-synth.json
 	nextpnr-gowin --json $^ --write $@ --device GW1NR-UV9QN881C6/I5 --cst tec0117.cst
 
 %-runber.fs: %-runber.json
 	gowin_pack -d GW1N-4 -o $@ $^
 
-%-runber.json: %.json
+%-runber.json: %-runber-synth.json
 	nextpnr-gowin --json $^ --write $@ --device GW1N-UV4LQ144C6/I5 --cst runber.cst
 
 %-tangnano.fs: %-tangnano.json
 	gowin_pack -d GW1N-1 -o $@ $^
 
-%-tangnano.json: %.json
+%-tangnano.json: %-tangnano-synth.json
 	nextpnr-gowin --json $^ --write $@ --device GW1N-LV1QN48C6/I5 --cst tangnano.cst
 
-attosoc.json: attosoc/attosoc.v attosoc/picorv32.v
+attosoc-tec0117-synth.json: attosoc/attosoc.v attosoc/picorv32.v
 	yosys -p "synth_gowin -json $@" $^
 
-nanolcd.json: nanolcd/TOP.v nanolcd/VGAMod.v
+nanolcd-tangano-synth.json: nanolcd/TOP.v nanolcd/VGAMod.v
 	yosys -p "synth_gowin -json $@" $^
 
-%.json: %.v
-	yosys -p "synth_gowin -json $@" $^
+%-synth.json: blinky.v
+	yosys -D LEDS_NR=$($(shell echo $(@) | cut -d\- -f 2)_leds) \
+		-p "synth_gowin -json $@" $^
 
 %-tec0117-prog: %-tec0117.fs
 	openFPGALoader -b tec0117 $^

--- a/examples/blinky.v
+++ b/examples/blinky.v
@@ -1,6 +1,6 @@
 module top (
 	input clk,
-	output reg [7:0] led
+	output [`LEDS_NR-1:0] led
 );
 
 reg [25:0] ctr_q;
@@ -12,6 +12,6 @@ always @(posedge clk)
 
 // Combinational code (boolean logic)
 assign ctr_d = ctr_q + 1'b1;
-assign led = ctr_q[25:18];
+assign led = ctr_q[25:25-`LEDS_NR];
 
 endmodule


### PR DESCRIPTION
By default the number of leds is hardcoded to 8. But depending to the targeted board this value is not always true and randoms pins are used for physical output not availables.

This PR add a verilog define to pass real number of leds:
- now it's no more possible to use a generic blinky.json to address all boards -> rule is renamed to append expliciitly board name and `synth` keyword
- the number of leds is provided trough Makefile variables

To clarify way to obtain number of leds:
```make
yosys -D LEDS_NR=$($(shell echo $(@) | cut -d\- -f 2)_leds) -p "synth_gowin -json $@" $^
```
is a two steps replacement:
1. `echo $(@) | cut -d\- -f 2` split rule name using '-' as separator and extract 2nd field (board name)
2. now `LEDS_NR=$($(shell echo $(@) | cut -d\- -f 2)_leds)` become `LEDS_NR=$(tangnano_leds)` (for tangano)
3. this new variable is replaced by the value 3

This patch drop reg to the entity section since led is combinatorial
