### PR TITLE
Support gw1ns 2c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN mkdir -p "/root/Documents/gowinsemi/" && \
     curl -so "/root/Documents/gowinsemi/GW1N-9 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG114-1.4E_GW1N-9%20Pinout.xlsx" && \
     curl -so "/root/Documents/gowinsemi/GW1NR-9 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG801-1.5E_GW1NR-9%20Pinout.xlsx" && \
     curl -so "/root/Documents/gowinsemi/GW1N-4 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG105-1.6E_GW1N-4%20Pinout.xlsx" && \
-    curl -so "/root/Documents/gowinsemi/GW1N-1 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG107-1.09E_GW1N-1%20Pinout.xlsx"
-
-# curl -so "/root/Documents/gowinsemi/GW1NS-2 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG825-1.2.1E_GW1NS-2C%20Pinout.xlsx"
+    curl -so "/root/Documents/gowinsemi/GW1N-1 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG107-1.09E_GW1N-1%20Pinout.xlsx" && \
+	curl -so "/root/Documents/gowinsemi/GW1NS-2C Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG825-1.2.1E_GW1NS-2C%20Pinout.xlsx" && \
+	curl -so "/root/Documents/gowinsemi/GW1NS-2 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG822-1.2.1E_GW1NS-2%20Pinout.xlsx"
 
 RUN pip install --no-cache-dir numpy pandas pillow crcmod openpyxl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN mkdir -p "/root/Documents/gowinsemi/" && \
     curl -so "/root/Documents/gowinsemi/GW1N-4 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG105-1.6E_GW1N-4%20Pinout.xlsx" && \
     curl -so "/root/Documents/gowinsemi/GW1N-1 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG107-1.09E_GW1N-1%20Pinout.xlsx"
 
+# curl -so "/root/Documents/gowinsemi/GW1NS-2 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG825-1.2.1E_GW1NS-2C%20Pinout.xlsx"
+
 RUN pip install --no-cache-dir numpy pandas pillow crcmod openpyxl
 
 WORKDIR /usr/src/apicula

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 .SECONDARY:
 .PHONY: all clean
-all: apycula/GW1N-1.pickle apycula/GW1N-9.pickle apycula/GW1N-4.pickle
+all: apycula/GW1N-1.pickle apycula/GW1N-9.pickle apycula/GW1N-4.pickle apycula/GW1NS-2.pickle
 
 %.json: apycula/dat19_h4x.py
 	python3 -m apycula.dat19_h4x $*

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -49,6 +49,8 @@ def read_bitstream(fname):
                         padding = 0
                     elif ba == b'\x06\x00\x00\x00\x01\x008\x1b':
                         padding = 0
+                    elif ba == b'\x06\x00\x00\x00\x03\x00\x18\x1b':
+                        padding = 0
                     else:
                         raise ValueError("Unsupported device", ba)
                 preamble = max(0, preamble-1)

--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -143,6 +143,9 @@ def get_pins(device):
     elif device == "GW1NR-9":
         header = 1
         start = 7
+    elif device == "GW1NS-2C":
+        header = 0
+        start = 7
     else:
         raise Exception("unsupported device")
     pkgs = pindef.all_packages(device, start, header)
@@ -164,6 +167,10 @@ def xls_pinout(family):
     elif family == "GW1N-4":
         return {
             "GW1N-4": get_pins("GW1N-4"),
+        }
+    elif family == "GW1NS-2":
+        return {
+            "GW1NS-2C": get_pins("GW1NS-2C"),
         }
     else:
         raise Exception("unsupported device")

--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -143,6 +143,9 @@ def get_pins(device):
     elif device == "GW1NR-9":
         header = 1
         start = 7
+    elif device == "GW1NS-2":
+        header = 0
+        start = 7
     elif device == "GW1NS-2C":
         header = 0
         start = 7
@@ -170,6 +173,7 @@ def xls_pinout(family):
         }
     elif family == "GW1NS-2":
         return {
+            "GW1NS-2": get_pins("GW1NS-2"),
             "GW1NS-2C": get_pins("GW1NS-2C"),
         }
     else:

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -80,9 +80,10 @@ def place(db, tilemap, bels):
                 bcol = db.cols-1
             tiledata = db.grid[brow][bcol]
             tile = tilemap[(brow, bcol)]
-            bits = tiledata.bels['BANK'].modes['DEFAULT']
-            for row, col in bits:
-                tile[row][col] = 1
+            if not len(tiledata.bels) == 0:
+                bits = tiledata.bels['BANK'].modes['DEFAULT']
+                for row, col in bits:
+                    tile[row][col] = 1
 
 
 def route(db, tilemap, pips):

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -140,7 +140,7 @@ def main():
 
     device = args.device
     # For tool integration it is allowed to pass a full part number
-    m = re.match("GW1N([A-Z]*)-(LV|UV)([0-9])([A-Z]{2}[0-9]+)(C[0-9]/I[0-9])", device)
+    m = re.match("GW1N([A-Z]*)-(LV|UV|UX)([0-9])C?([A-Z]{2}[0-9]+)(C[0-9]/I[0-9])", device)
     if m:
         luts = m.group(3)
         device = f"GW1N-{luts}"

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -31,6 +31,12 @@ if not gowinhome:
 device = sys.argv[1]
 
 params = {
+    "GW1NS-2": {
+        "package": "QN48",
+        "header": 0,
+        "device": "GW1NS-2C-QN48-5",
+        "partnumber": "GW1NS-UX2CQN48C5/I4",
+    },
     "GW1N-9": {
         "package": "PG256",
         "header": 0,

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -32,10 +32,10 @@ device = sys.argv[1]
 
 params = {
     "GW1NS-2": {
-        "package": "QN48",
+        "package": "LQ144",
         "header": 0,
-        "device": "GW1NS-2C-QN48-5",
-        "partnumber": "GW1NS-UX2CQN48C5/I4",
+        "device": "GW1NS-2C-LQ144-5",
+        "partnumber": "GW1NS-UX2CLQ144C5/I4",
     },
     "GW1N-9": {
         "package": "PG256",

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,9 @@
+honeycomb=3
 runber_leds=8
 tangnano_leds=3
 tec0117_leds=8
 
-all: attosoc-tec0117.fs blinky-tec0117.fs blinky-runber.fs blinky-tangnano.fs
+all: attosoc-tec0117.fs blinky-tec0117.fs blinky-runber.fs blinky-tangnano.fs blinky-honeycomb.fs
 
 %-tec0117.fs: %-tec0117.json
 	gowin_pack -d GW1N-9 -o $@ $^
@@ -22,6 +23,12 @@ all: attosoc-tec0117.fs blinky-tec0117.fs blinky-runber.fs blinky-tangnano.fs
 %-tangnano.json: %-tangnano-synth.json
 	nextpnr-gowin --json $^ --write $@ --device GW1N-LV1QN48C6/I5 --cst tangnano.cst
 
+%-honeycomb.fs: %-honeycomb.json
+	gowin_pack -d GW1NS-2 -o $@ $^
+
+%-honeycomb.json: %-honeycomb-synth.json
+	nextpnr-gowin --json $^ --write $@ --device GW1NS-UX2CQN48C5/I4 --cst honeycomb.cst
+
 attosoc-tec0117-synth.json: attosoc/attosoc.v attosoc/picorv32.v
 	yosys -p "synth_gowin -json $@" $^
 
@@ -31,6 +38,9 @@ nanolcd-tangano-synth.json: nanolcd/TOP.v nanolcd/VGAMod.v
 %-synth.json: blinky.v
 	yosys -D LEDS_NR=$($(shell echo $(@) | cut -d\- -f 2)_leds) \
 		-p "synth_gowin -json $@" $^
+
+%-honeycomb-prog: %-honeycomb.fs
+	openFPGALoader -b honeycomb $^
 
 %-tec0117-prog: %-tec0117.fs
 	openFPGALoader -b tec0117 $^

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-honeycomb=3
+honeycomb_leds=3
 runber_leds=8
 tangnano_leds=3
 tec0117_leds=8

--- a/examples/honeycomb.cst
+++ b/examples/honeycomb.cst
@@ -1,0 +1,6 @@
+//Part Number: GW1NS-UX2CQN48C5/I4
+
+IO_LOC "clk" 10;
+IO_LOC "led[0]" 32;
+IO_LOC "led[1]" 33;
+IO_LOC "led[2]" 34;

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ Currently supported boards are
  * Trenz TEC0117: GW1NR-UV9QN881C6/I5
  * Sipeed Tang Nano: GW1N-LV1QN48C6/I5
  * Seeed RUNBER: GW1N-UV4LQ144C6/I5
+ * @Disasm honeycomb: GW1NS-UX2CQN48C5/I4
 
 Install the tools with pip.
 
@@ -30,7 +31,7 @@ export PATH="/home/pepijn/.local/bin:$PATH" # add binaries to the path
 
 From there, compile a blinky.
 
-The example below is for the Trenz TEC0117. For other devices, use the model numbers listed above for `--device`, and replace `tec0117` with `runber` or `tangnano` accordingly.
+The example below is for the Trenz TEC0117. For other devices, use the model numbers listed above for `--device`, and replace `tec0117` with `runber`, `tangnano` or `honeycomb` accordingly.
 You can also use the Makefile in the examples folder to build the examples.
 
 ```bash
@@ -55,6 +56,7 @@ Version 1.9.3.01 of the Gowin vendor tools. Newer versions may work, but have no
 * `UG114-1.4E_GW1N-9 Pinout.xlsx`
 * `UG801-1.5E_GW1NR-9 Pinout.xlsx`
 * `UG105-1.6E_GW1N-4 Pinout.xlsx`
+* `UG825-1.2.1E_GW1NS-2C Pinout.xlsx`
 
 Alternatively, you can use the `Dockerfile` to run the fuzzers in a container.
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     package_data={
-        'apycula': ['GW1N-1.pickle', 'GW1N-4.pickle', 'GW1N-9.pickle'],
+        'apycula': ['GW1N-1.pickle', 'GW1NS-2.pickle', 'GW1N-4.pickle', 'GW1N-9.pickle'],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR add support for GW1NS-2C FPGA:
The first commit avoid a crash like:
```bash
  File "/xxx/apicula/apycula/gowin_pack.py", line 91, in place
    bits = tiledata.bels['BANK'].modes['DEFAULT']
KeyError: 'BANK'
make: *** [Makefile:27 : blinky-honeycomb.fs] Erreur 1
```
Second commit add everything required to generate the pickle for this device and update readme (Dockerfile is partially updated -> needs to store xls somewhere)
And finally last commit add the honeycomb in examples