### PR TITLE
Use aliases of I/O standards in the packer

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -33,6 +33,15 @@ def get_pips(data):
 def infovaluemap(infovalue, start=2):
     return {tuple(iv[:start]):iv[start:] for iv in infovalue}
 
+iostd_alias = {
+        "HSTL18_II"  : "HSTL18_I",
+        "SSTL18_I"   : "HSTL18_I",
+        "SSTL18_II"  : "HSTL18_I",
+        "HSTL15_I"   : "SSTL15",
+        "SSTL25_II"  : "SSTL25_I",
+        "SSTL33_II"  : "SSTL33_I",
+        "LVTTL33"    : "LVCMOS33",
+        }
 _banks = {}
 def place(db, tilemap, bels):
     for typ, row, col, num, parms, attrs in bels:
@@ -80,7 +89,7 @@ def place(db, tilemap, bels):
                     if iostd and iostd != flag_name_val[1]:
                         raise Exception("Different I/O modes for the same bank were specified: " +
                                 f"{iostd} and {flag_name_val[1]}")
-                    iostd = flag_name_val[1]
+                    iostd = iostd_alias.get(flag_name_val[1], flag_name_val[1])
 
             # first used pin sets bank's iostd
             # XXX default io standard may be board-dependent!

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -13,7 +13,7 @@ from apycula.bslib import read_bitstream
 from apycula.wirenames import wirenames
 
 # bank iostandards
-# XXX
+# XXX default io standard may be board-dependent!
 _banks = {0: "LVCMOS33", 1: "LVCMOS18", 2: "LVCMOS18", 3: "LVCMOS18"}
 
 # noiostd --- this is the case when the function is called


### PR DESCRIPTION
Other than that:
 - small comments in places to be corrected later
 - a tiny speedup by changing the order of the loops

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>