### PR TITLE
Create .cst (constraints) file from gowin_pack and gowin_unpack

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -61,9 +61,6 @@ def place(db, tilemap, bels, cst):
         tiledata = db.grid[row-1][col-1]
         tile = tilemap[(row-1, col-1)]
         if typ == "SLICE":
-            # XXX skip power
-            if not cellname.startswith('\$PACKER'):
-                cst.cells[cellname] = f"R{row}C{col}[{int(num) % 4}][{_sides[int(num)]}]"
             lutmap = tiledata.bels[f'LUT{num}'].flags
             init = str(parms['INIT'])
             init = init*(16//len(init))
@@ -78,6 +75,13 @@ def place(db, tilemap, bels, cst):
                 dffbits = tiledata.bels[f'DFF{num}'].modes[mode]
                 for brow, bcol in dffbits:
                     tile[brow][bcol] = 1
+                # XXX skip power
+                if not cellname.startswith('\$PACKER'):
+                    cst.cells[cellname] = f"R{row}C{col}[{int(num) % 3}][{_sides[int(num) + 1]}]"
+            else:
+                # XXX skip power
+                if not cellname.startswith('\$PACKER'):
+                    cst.cells[cellname] = f"R{row}C{col}[{int(num) % 4}][{_sides[int(num)]}]"
 
         elif typ == "IOB":
             edge = 'T'

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -11,6 +11,7 @@ from apycula import chipdb
 from apycula import bslib
 from apycula.wirenames import wirenames, wirenumbers
 
+_verilog_name = re.compile(r"^[A-Za-z_0-9][A-Za-z_0-9$]*$")
 def sanitize_name(name):
     retname = name
     if name[-3:] == '_LC':
@@ -18,7 +19,9 @@ def sanitize_name(name):
     elif name[-6:] == '_DFFLC':
         retname = name[:-6]
     elif name[-4:] == '$iob':
-        return name[:-4]
+        retname = name[:-4]
+    if _verilog_name.fullmatch(retname):
+        return retname
     return f"\{retname} "
 
 def get_bels(data):

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -214,7 +214,7 @@ def main():
     parser.add_argument('-d', '--device', required=True)
     parser.add_argument('-o', '--output', default='pack.fs')
     parser.add_argument('-c', '--compress', default=False, action='store_true')
-    parser.add_argument('-s', '--cst', default='pack.cst')
+    parser.add_argument('-s', '--cst', default=None)
     parser.add_argument('--png')
 
     args = parser.parse_args()
@@ -242,8 +242,9 @@ def main():
     if args.png:
         bslib.display(args.png, res)
     bslib.write_bitstream(args.output, res, db.cmd_hdr, db.cmd_ftr, args.compress)
-    with open(args.cst, "w") as f:
-            cst.write(f)
+    if args.cst:
+        with open(args.cst, "w") as f:
+                cst.write(f)
 
 if __name__ == '__main__':
     main()

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -33,6 +33,15 @@ def get_pips(data):
 def infovaluemap(infovalue, start=2):
     return {tuple(iv[:start]):iv[start:] for iv in infovalue}
 
+iostd_alias = {
+        "HSTL18_II"  : "HSTL18_I",
+        "SSTL18_I"   : "HSTL18_I",
+        "SSTL18_II"  : "HSTL18_I",
+        "HSTL15_I"   : "SSTL15",
+        "SSTL25_II"  : "SSTL25_I",
+        "SSTL33_II"  : "SSTL33_I",
+        "LVTTL33"    : "LVCMOS33",
+        }
 _banks = {}
 def place(db, tilemap, bels):
     for typ, row, col, num, parms, attrs in bels:
@@ -80,7 +89,7 @@ def place(db, tilemap, bels):
                     if iostd and iostd != flag_name_val[1]:
                         raise Exception("Different I/O modes for the same bank were specified: " +
                                 f"{iostd} and {flag_name_val[1]}")
-                    iostd = flag_name_val[1]
+                    iostd = iostd_alias.get(flag_name_val[1], flag_name_val[1])
 
             # first used pin sets bank's iostd
             # XXX default io standard may be board-dependent!

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -58,7 +58,7 @@ iostd_alias = {
         "LVTTL33"    : "LVCMOS33",
         }
 _banks = {}
-_sides = "AAAABBBB"
+_sides = "AB"
 def place(db, tilemap, bels, cst):
     for typ, row, col, num, parms, attrs, cellname in bels:
         tiledata = db.grid[row-1][col-1]
@@ -78,13 +78,9 @@ def place(db, tilemap, bels, cst):
                 dffbits = tiledata.bels[f'DFF{num}'].modes[mode]
                 for brow, bcol in dffbits:
                     tile[brow][bcol] = 1
-                # XXX skip power
-                if not cellname.startswith('\$PACKER'):
-                    cst.cells[cellname] = f"R{row}C{col}[{int(num) % 3}][{_sides[int(num) + 1]}]"
-            else:
-                # XXX skip power
-                if not cellname.startswith('\$PACKER'):
-                    cst.cells[cellname] = f"R{row}C{col}[{int(num) % 4}][{_sides[int(num)]}]"
+            # XXX skip power
+            if not cellname.startswith('\$PACKER'):
+                cst.cells[cellname] = f"R{row}C{col}[{int(num) // 2}][{_sides[int(num) % 2]}]"
 
         elif typ == "IOB":
             edge = 'T'

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -129,6 +129,7 @@ def portname(n):
         return "OEN"
     return n
 
+_sides = "AAAABBBB"
 def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
     # db is 0-based, floorplanner is 1-based
     row = dbrow+1
@@ -156,6 +157,7 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
             lut.portmap['I3'] = f"R{row}C{col}_D{idx}"
             mod.wires.update(lut.portmap.values())
             mod.primitives[name] = lut
+            cst.cells[name] = f"R{row}C{col}[{int(idx) % 4}][{_sides[int(idx)]}]"
         elif typ == "DFF":
             kind, = flags # DFF only have one flag
             idx = int(idx)
@@ -170,6 +172,7 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
                 dff.portmap[port] = f"R{row}C{col}_LSR{idx//2}"
             mod.wires.update(dff.portmap.values())
             mod.primitives[name] = dff
+            cst.cells[name] = f"R{row}C{col}[{int(idx) % 3}][{_sides[int(idx) + 1]}]"
 
         elif typ == "IOB":
             try:

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -129,7 +129,7 @@ def portname(n):
         return "OEN"
     return n
 
-_sides = "AAAABBBB"
+_sides = "AB"
 def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
     # db is 0-based, floorplanner is 1-based
     row = dbrow+1
@@ -157,7 +157,7 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
             lut.portmap['I3'] = f"R{row}C{col}_D{idx}"
             mod.wires.update(lut.portmap.values())
             mod.primitives[name] = lut
-            cst.cells[name] = f"R{row}C{col}[{int(idx) % 4}][{_sides[int(idx)]}]"
+            cst.cells[name] = f"R{row}C{col}[{int(idx) // 2}][{_sides[int(idx) % 2]}]"
         elif typ == "DFF":
             kind, = flags # DFF only have one flag
             idx = int(idx)
@@ -172,8 +172,7 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
                 dff.portmap[port] = f"R{row}C{col}_LSR{idx//2}"
             mod.wires.update(dff.portmap.values())
             mod.primitives[name] = dff
-            cst.cells[name] = f"R{row}C{col}[{int(idx) % 3}][{_sides[int(idx) + 1]}]"
-
+            cst.cells[name] = f"R{row}C{col}[{int(idx) // 2}][{_sides[int(idx) % 2]}]"
         elif typ == "IOB":
             try:
                 kind, = flags.intersection(iobmap.keys())

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -13,7 +13,7 @@ from apycula.bslib import read_bitstream
 from apycula.wirenames import wirenames
 
 # bank iostandards
-# XXX
+# XXX default io standard may be board-dependent!
 _banks = {0: "LVCMOS33", 1: "LVCMOS18", 2: "LVCMOS18", 3: "LVCMOS18"}
 
 # noiostd --- this is the case when the function is called


### PR DESCRIPTION
The generated files can be fed to the vendor p&r along with a netlist, which must be created by specifying the -vout and -json options simultaneously, e.g:

yosys -p "synth_gowin -vout shift-vout.v -json shift.json" shift.v 
nextpnr-gowin --json shift.json --write shift-pnr.json --device GW1N-LV1QN48C6/I5 --cst tangnannanno.cst

gowin_pack -d GW1N-1 -o ~/tmp/shift.fs --cst ~/tmp/shift.cst shift-pnr.json

You can then use shift-vout.v and ~/tmp/shift.cst as a new netlist/restriction pair to recompile.

At the moment both programs can contain bugs and gowin_pack gives better results compared to gowin_unpack:)