### PR TITLE
Fix the fuzzing of the DFFs.

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -297,6 +297,27 @@ def shared2flag(dev):
                                 belb.flags[mode+"C"] = mode_cb
                                 bits -= mode_cb
 
+def dff_clean(dev):
+    """ Clean DFF mode bits: fuzzer captures a bit of the neighboring trigger."""
+    seen_bels = []
+    for idx, row in enumerate(dev.grid):
+        for jdx, td in enumerate(row):
+            for name, bel in td.bels.items():
+                if name[0:3] == "DFF":
+                    if bel in seen_bels:
+                        continue
+                    seen_bels.append(bel)
+                    # find extra bit
+                    extra_bits = set()
+                    for bits in bel.modes.values():
+                        if extra_bits:
+                            extra_bits &= bits
+                        else:
+                            extra_bits = bits.copy()
+                    # remove it
+                    for mode, bits in bel.modes.items():
+                        bits -= extra_bits
+
 def diff2flag(dev):
     """ Minimize bits for flag values and calc flag bitmask"""
     seen_bels = []

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -108,6 +108,7 @@ def parse_tile_(db, row, col, tile, default=True, noalias=False, noiostd = True)
 
 dffmap = {
     "DFF": None,
+    "DFFN": None,
     "DFFS": "SET",
     "DFFR": "RESET",
     "DFFP": "PRESET",

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -75,6 +75,7 @@ Fuzzer = namedtuple('Fuzzer', [
 
 dffmap = {
     "DFF": None,
+    "DFFN": None,
     "DFFS": "SET",
     "DFFR": "RESET",
     "DFFP": "PRESET",
@@ -234,7 +235,7 @@ iostd_pull_mode = {
             "PCI33"       : [],
         }
 
-iostandards = ["", "LVCMOS33", "LVCMOS18", "LVCMOS25", "LVCMOS15", "LVCMOS12",
+iostandards = ["", "LVCMOS18", "LVCMOS33", "LVCMOS25", "LVCMOS15", "LVCMOS12",
       "SSTL25_I", "SSTL33_I", "SSTL15", "HSTL18_I", "PCI33"]
 
 AttrValues = namedtuple('ModeAttr', [
@@ -667,6 +668,7 @@ if __name__ == "__main__":
     chipdb.dat_portmap(dat, db)
     chipdb.dat_aliases(dat, db)
     chipdb.diff2flag(db)
+    chipdb.dff_clean(db)
     # XXX not used for IOB but...
     #chipdb.shared2flag(db)
 


### PR DESCRIPTION
The situation where an extra bit was captured meant that
only two identical registers could be placed in a single slide.
It is now possible to place registers of joint types, i.e:
DFFS and DFFR
DFFP and DFFC
DFFNS and DFFNR
DFFNP and DFFNC
as well as their CE versions.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>