### PR TITLE
chipdb: alu: mask CUPCDN functionality

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -198,7 +198,8 @@ def fse_luts(fse, ttyp):
             # CDN
             add_alu_mode(mode, bel.modes, lut, "7",     "0101000001011111")
             # CUPCDN
-            add_alu_mode(mode, bel.modes, lut, "8",     "1010000001011010")
+            # The functionality of this seems to be the same with SUB
+            # add_alu_mode(mode, bel.modes, lut, "8",     "1010000001011010")
             # MULT   INIT="0111 1000 1000 1000"
             #
             add_alu_mode(mode, bel.modes, lut, "9",     "0111100010001000")


### PR DESCRIPTION
CUPCDN functionality seems to behave exactly the same with SUB, which
leads to unpacking failure when unpacking a bitstream that utilizes
SUB.

Mask the functionality in chipdb generation code now.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>