### PR TITLE
Switch to read the banks encoding from .FSE

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -46,6 +46,7 @@ class Bel:
     # banks
     bank_mask: Set[Coord] = field(default_factory=set)
     bank_flags: Dict[str, Set[Coord]] = field(default_factory=dict)
+    bank_input_only_modes: Dict[str, str] = field(default_factory=dict)
     # there can be only one mode, modes are exclusive
     modes: Dict[Union[int, str], Set[Coord]] = field(default_factory=dict)
     portmap: Dict[str, str] = field(default_factory=dict)
@@ -98,14 +99,28 @@ class Device:
     def width(self):
         return sum(tile.width for tile in self.grid[0])
 
+    # XXX consider removing
     @property
     def corners(self):
         # { (row, col) : bank# }
         return {
-            (0, 0) : 0,
-            (0, self.cols - 1) : 1,
-            (self.rows - 1, self.cols - 1) : 2,
-            (self.rows - 1, 0) : 3}
+            (0, 0) : '0',
+            (0, self.cols - 1) : '1',
+            (self.rows - 1, self.cols - 1) : '2',
+            (self.rows - 1, 0) : '3'}
+
+    # Some chips have bits responsible for different banks in the same corner tile.
+    # Here stores the correspondence of the bank number to the (row, col) of the tile.
+    @property
+    def bank_tiles(self):
+        # { bank# : (row, col) }
+        res = {}
+        for pos in self.corners.keys():
+            row, col = pos
+            for bel in self.grid[row][col].bels.keys():
+                if bel[0:4] == 'BANK':
+                    res.update({ bel[4:] : pos })
+        return res
 
 def unpad(fuses, pad=-1):
     try:
@@ -245,6 +260,37 @@ def fse_luts(fse, ttyp):
         }
     return luts
 
+# XXX This is not a nice way, I will replace it with automatic creation of banks
+# in the very near future.
+def set_banks(device, db):
+    # fill the bank# : corner tile table
+    w = db.cols - 1
+    h = db.rows - 1
+    if device == 'GW1NZ-1':
+        db.grid[0][0].bels.setdefault('BANK0', Bel())
+        db.grid[0][w].bels.setdefault('BANK1', Bel())
+    elif device == 'GW1NS-2':
+        db.grid[0][0].bels.setdefault('BANK0', Bel())
+        db.grid[0][w].bels.setdefault('BANK1', Bel())
+        db.grid[h][w].bels.setdefault('BANK2', Bel())
+        db.grid[0][0].bels.setdefault('BANK3', Bel())
+    elif device == 'GW1NS-4':
+        db.grid[0][0].bels.setdefault('BANK0', Bel())
+        db.grid[0][w].bels.setdefault('BANK1', Bel())
+        db.grid[h][w].bels.setdefault('BANK2', Bel())
+        db.grid[h][w].bels.setdefault('BANK3', Bel())
+    elif device == 'GW1N-9':
+        db.grid[0][0].bels.setdefault('BANK0', Bel())
+        db.grid[0][w].bels.setdefault('BANK1', Bel())
+        db.grid[h][w].bels.setdefault('BANK2', Bel())
+        db.grid[h][0].bels.setdefault('BANK3', Bel())
+        db.grid[0][0].bels.setdefault('BANK10', Bel())
+        db.grid[0][0].bels.setdefault('BANK30', Bel())
+    else:
+        db.grid[0][0].bels.setdefault('BANK0', Bel())
+        db.grid[0][w].bels.setdefault('BANK1', Bel())
+        db.grid[h][w].bels.setdefault('BANK2', Bel())
+        db.grid[h][0].bels.setdefault('BANK3', Bel())
 
 def from_fse(fse):
     dev = Device()
@@ -457,6 +503,9 @@ def get_route_bits(db, row, col):
     for w in db.grid[row][col].pips.values():
         for v in w.values():
             bits.update(v)
+    for w in db.grid[row][col].clock_pips.values():
+        for v in w.values():
+            bits.update(v)
     return bits
 
 def diff2flag(dev):
@@ -496,7 +545,7 @@ def diff2flag(dev):
                             # decode bits don't include flags
                             for _, flag_rec in mode_rec.flags.items():
                                 mode_rec.decode_bits -= flag_rec.mask
-                elif name == "BANK":
+                elif name[0:4] == "BANK":
                     noise_bits = None
                     for bits in bel.bank_flags.values():
                         if noise_bits != None:
@@ -564,7 +613,7 @@ def loc2pin_name(db, row, col):
     return f"IO{side}{idx}"
 
 def loc2bank(db, row, col):
-    """ returns bank index 0...n
+    """ returns bank index '0'...'n'
     """
     bank =  db.corners.get((row, col))
     if bank == None:

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -164,6 +164,9 @@ def place(db, tilemap, bels, cst, args):
 
             cst.attrs.setdefault(cellname, {}).update({"IO_TYPE": iostd})
             # collect flag bits
+            if iostd not in iob.iob_flags.keys():
+                print(f"Warning: {iostd} isn't allowed for IO{edge}{idx}{num}. Set LVCMOS18 instead.")
+                iostd = 'LVCMOS18'
             bits = iob.iob_flags[iostd][mode].encode_bits.copy()
             # XXX OPEN_DRAIN must be after DRIVE
             attrs_keys = attrs.keys()
@@ -197,28 +200,26 @@ def place(db, tilemap, bels, cst, args):
 
             if pinless_io:
                 return
-            #bank enable
-            for pos, bnum in db.corners.items():
-                if bnum == bank:
-                    break
-            brow, bcol = pos
-            tiledata = db.grid[brow][bcol]
-            tile = tilemap[(brow, bcol)]
-            if not len(tiledata.bels) == 0:
-                bank_bel = tiledata.bels['BANK']
-                bits = bank_bel.modes['ENABLE'].copy()
-                # iostd flag
-                bits |= bank_bel.bank_flags[iostd]
-                for row, col in bits:
-                    tile[row][col] = 1
     # If the entire bank has only inputs, the LVCMOS12/15/18 bit is set
     # in each IBUF regardless of the actual I/O standard.
-    for _, bank_desc in _banks.items():
+    for bank, bank_desc in _banks.items():
+        #bank enable
+        brow, bcol = db.bank_tiles[bank]
+        tiledata = db.grid[brow][bcol]
+        btile = tilemap[(brow, bcol)]
+        bank_bel = tiledata.bels['BANK' + bank]
+        bits = bank_bel.modes['ENABLE'].copy()
+        iostd = bank_desc.iostd
         if bank_desc.inputs_only:
             if bank_desc.iostd in {'LVCMOS33', 'LVCMOS25'}:
                 for bel, tile in bank_desc.bels_tiles:
                     for row, col in bel.lvcmos121518_bits:
                         tile[row][col] = 1
+            iostd = bank_bel.bank_input_only_modes[bank_desc.iostd]
+        # iostd flag
+        bits |= bank_bel.bank_flags[iostd]
+        for row, col in bits:
+            btile[row][col] = 1
 
 def route(db, tilemap, pips):
     for row, col, src, dest in pips:

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -236,7 +236,7 @@ def ram16_remove_bels(bels):
         bels.pop(bel, None)
 
 _sides = "AB"
-def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
+def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cst, db):
     # db is 0-based, floorplanner is 1-based
     row = dbrow+1
     col = dbcol+1
@@ -368,12 +368,6 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
                 name_val = flg.split('=')
                 cst.attrs.setdefault(name, {}).update({name_val[0] : name_val[1]})
 
-        elif typ == "CFG":
-            for flag in flags:
-                for name in cfg.settings.keys():
-                    if name.startswith(flag):
-                        cfg.settings[name] = 'true'
-
     # gnd = codegen.Primitive("GND", "mygnd")
     # gnd.portmap["G"] = "VSS"
     # mod.primitives["mygnd"] = gnd
@@ -444,7 +438,7 @@ def main():
         except KeyError:
             continue
         bels, pips, clock_pips = parse_tile_(db, row, col, t)
-        tile2verilog(row, col, bels, pips, clock_pips, mod, cfg, cst, db)
+        tile2verilog(row, col, bels, pips, clock_pips, mod, cst, db)
 
     for idx, t in bm.items():
         row, col = idx
@@ -466,7 +460,7 @@ def main():
         else:
             removeLUTs(bels)
         ram16_remove_bels(bels)
-        tile2verilog(row, col, bels, pips, clock_pips, mod, cfg, cst, db)
+        tile2verilog(row, col, bels, pips, clock_pips, mod, cst, db)
 
     with open(args.output, 'w') as f:
         mod.write(f)

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -91,14 +91,14 @@ def parse_tile_(db, row, col, tile, default=True, noalias=False, noiostd = True)
                 #print(mode, sorted(bits))
                 if bits == mode_bits and (default or bits):
                     bels.setdefault(name, set()).add(mode)
-                    if name == "BANK":
+                    if name[0:4] == "BANK":
                         # set iostd for bank
                         flag_bits = {(row, col)
                                       for row, col in bel.bank_mask
                                       if tile[row][col] == 1}
                         for iostd, bits in bel.bank_flags.items():
                             if bits == flag_bits:
-                                _banks[chipdb.loc2bank(db, row, col)] = iostd
+                                _banks[name[4:]] = iostd
                                 break
                         # mode found
                         break
@@ -313,7 +313,7 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cfg, cst, db):
             ram16.portmap['RAD'] = [f"R{row}C{col}_{x}0" for x in "ABCD"]
             ram16.portmap['DO'] = [f"R{row}C{col}_F{x}" for x in range(4)]
             mod.wires.update(chain.from_iterable([x if isinstance(x, list) else [x] for x in ram16.portmap.values()]))
-            mod.primitives[name] = ram16                                       
+            mod.primitives[name] = ram16
 
         elif typ == "DFF":
             #print(flags)
@@ -408,10 +408,8 @@ def main():
     parser.add_argument('bitstream')
     parser.add_argument('-d', '--device', required=True)
     parser.add_argument('-o', '--output', default='unpack.v')
-    parser.add_argument('-c', '--config', default=None)
     parser.add_argument('-s', '--cst', default=None)
-    parser.add_argument('--noalu', metavar='N', type = int,
-                        default = 0, help = '0 - detect the ALU')
+    parser.add_argument('--noalu', action = 'store_false')
 
     args = parser.parse_args()
 
@@ -430,7 +428,6 @@ def main():
     bitmap = read_bitstream(args.bitstream)[0]
     bm = chipdb.tile_bitmap(db, bitmap)
     mod = codegen.Module()
-    cfg = codegen.DeviceConfig(default_device_config())
     cst = codegen.Constraints()
 
     for (drow, dcol, dname), (srow, scol, sname) in db.aliases.items():
@@ -473,10 +470,6 @@ def main():
 
     with open(args.output, 'w') as f:
         mod.write(f)
-
-    if args.config:
-        with open(args.config, 'w') as f:
-            cfg.write(f)
 
     if args.cst:
         with open(args.cst, 'w') as f:

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -220,7 +220,7 @@ def is_illegal(iostd, pin, attr, attr_value = None):
     # bottom pins GW1NS-4 (bank 3) support LVCMOS only
     if iostd != '' and device == 'GW1NS-4':
         if pin.startswith('IOB'):
-            return (not iostd.startswith('LVCMOS') and not iostd != 'PCI33')
+            return (not iostd.startswith('LVCMOS') and iostd != 'PCI33')
     if device == 'GW1NZ-1':
          return iostd in ["SSTL25_I", "SSTL33_I", "SSTL15", "HSTL18_I"]
     if device == 'GW1N-9C' and pin.startswith('IOB') and attr == 'DRIVE':

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -52,15 +52,20 @@ def recode_idx_gw1ns_4(idx):
         new_idx -= 1
     if idx >= 70:
         new_idx -= 3
+    if idx >= 79:
+        new_idx += 1
+    if idx >= 83:
+        new_idx -= 1
     return new_idx
 
 def recode_idx_gw1n9(idx):
     new_idx = idx
     if idx >= 69:
         new_idx += 3
-    if idx == 79:
-        new_idx += 4
-        return new_idx
+    if idx >= 79:
+        new_idx += 1
+    if idx >= 83:
+        new_idx -=1
     return new_idx
 
 def recode_idx_gw1n4(idx):
@@ -71,6 +76,10 @@ def recode_idx_gw1n4(idx):
         new_idx -= 1
     if idx >= 70:
         new_idx -= 2
+    if idx >= 73:
+        new_idx -= 1
+    if idx >= 79:
+        new_idx += 1
     return new_idx
 
 def recode_idx_gw1nz_1(idx):

--- a/doc/longval-tables.md
+++ b/doc/longval-tables.md
@@ -94,6 +94,66 @@ Perhaps the most difficult attribute at the moment. It uses the same fuses as `D
 |:-----:|:-----------:|
 |   ON  |  {55, 70}   |
 
-(An example will come later)
+NOISE fuse: {55, 72}
+
+example: 'OPEN_DRAIN=ON':
+
+16mA LVCMOS33 fuse: 
+
+[12, 52, 56, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3210, 3238, 3245, 3263, 3273, 3281, -1, -1, -1, -1, -1, -1]
+
+ON fuse:
+
+[10, 55, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3273, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
+
+NOISE fuse:
+
+[7, 55, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3238, 3263, 3273, 3281, -1, -1, -1, -1, -1, -1, -1, -1]
+
+Thus we clear {3210, 3245} and set {3273}.
 
 
+## Tables of corner tiles
+Corner tiles enable I/O banks and set logical levels.
+
+Table 37.
+
+The key includes the bank number, usually unchanged, but there are strange numbers like 10 or 30. which still need to be investigated.
+
+Simple modes are found simply by the standard code:
+
+| Value     | Code  |
+|:---------:|:-----:|
+| LVCMOS33  |  68   |
+| LVCMOS25  |  67   |
+| LVCMOS18  |  66   |
+| LVCMOS15  |  65   |
+| LVCMOS12  |  64   |
+
+example: 'IO_TYPE=LVCMOS15'
+
+[2, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2797, 2813, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
+
+
+Complex modes are obtained by adding fuse 79:
+
+| Mode      | Fuses  |
+|:---------:|:-----------------------:|
+| SSTL15    |  fuses(65) + fuses(79)  |
+| HSTL18_I  |  fuses(66) + fuses(79)  |
+| SSTL25_I  |  fuses(67) + fuses(79)  |
+| SSTL33_I  |  fuses(68) + fuses(79)  |
+
+example: 'IO_TYPE=SSTL15'
+
+Fuse 79: 
+
+[3, 79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2229, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
+
+Fuse 65:
+
+[3, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2181, 2197, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
+
+Thus we set {2181, 2197, 2229}
+
+TODO: Describe the situation when all pins in the bank are working as input


### PR DESCRIPTION
  - store which mode is used for the case of inputs only;
  - handle multiple banks in the same corner tile;
  - add clock routes to the routing bits;
  - warn if wrong IOSTD used for pin;
  - use strings as the bank indices;
  - the new IDE does not use a device configuration file, so do not write it;
  - recoding update for GW1N-9;
  - LVCMOS12 is back;
  - document the 37 longval table.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>