### PR TITLE
VCC to GSR hack

### DIFF
--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -846,6 +846,16 @@ def run_pnr(mod, constr, config):
             input()
             return None
 
+def connect_VCC_to_GSR(db):
+    for dst, srcs in db.grid[0][0].pips.items():
+        if 'VCC' in srcs.keys():
+            if dst in db.grid[0][0].pips['C4'].keys():
+                bits = db.grid[0][0].pips['C4'][dst] | db.grid[0][0].pips[dst]['VCC']
+                for bit in bits:
+                    db.template[bit] = 1
+                db.grid[0][0].pips.pop(dst)
+                db.grid[0][0].pips.pop('C4')
+                return
 
 # module + constraints + config
 DataForPnr = namedtuple('DataForPnr', ['modmap', 'cstmap', 'cfgmap'])
@@ -1071,6 +1081,10 @@ if __name__ == "__main__":
 
     db.grid[0][0].bels['CFG'].flags['UNK0'] = {(3, 1)}
     db.grid[0][0].bels['CFG'].flags['UNK1'] = {(3, 2)}
+    db.template[(3, 1)] = 1
+    db.template[(3, 2)] = 1
+    # GSR
+    connect_VCC_to_GSR(db)
 
     for row, col, ttyp in corners:
         if "BANK" not in db.grid[row][col].bels.keys():


### PR DESCRIPTION
Connect the VCC to the GSR input directly in the template and remove the
ability to use these pips for routing.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>