### PR TITLE
gowin_unpack: Change the constant representation

### DIFF
--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -285,7 +285,7 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cst, db):
             else:
                 name = f"R{row}C{col}_LUT4_{idx}"
                 lut = codegen.Primitive("LUT4", name)
-                lut.params["INIT"] = f"16'b{val:016b}"
+                lut.params["INIT"] = f"16'h{val:04x}"
                 lut.portmap['F'] = f"R{row}C{col}_F{idx}"
                 lut.portmap['I0'] = f"R{row}C{col}_A{idx}"
                 lut.portmap['I1'] = f"R{row}C{col}_B{idx}"
@@ -430,8 +430,8 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cst, db):
     # vcc = codegen.Primitive("VCC", "myvcc")
     # vcc.portmap["V"] = "VCC"
     # mod.primitives["myvcc"] = vcc
-    mod.assigns.append(("VCC", "1"))
-    mod.assigns.append(("VSS", "0"))
+    mod.assigns.append(("VCC", "1'b1"))
+    mod.assigns.append(("VSS", "1'b0"))
 
 def default_device_config():
     return {

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -378,10 +378,10 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cst, db):
                 wname = portmap[port]
                 oddr.portmap[port] = f"R{row}C{col}_{wname}"
             oddr.portmap['Q0'] = f"R{row}C{col}_{portmap['D0']}_IOL"
-            # XXX implement ODDR with TBUF
-            oddr.portmap['Q1'] = ""
             #oddr.portmap['Q1'] = f"R{row}C{col}_{portmap['Q1']}_IOL"
             mod.wires.update(oddr.portmap.values())
+            # XXX implement ODDR with TBUF
+            oddr.portmap['Q1'] = ""
             mod.primitives[name] = oddr
         elif typ == "IOB":
             try:

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -378,6 +378,8 @@ def tile2verilog(dbrow, dbcol, bels, pips, clock_pips, mod, cst, db):
                 wname = portmap[port]
                 oddr.portmap[port] = f"R{row}C{col}_{wname}"
             oddr.portmap['Q0'] = f"R{row}C{col}_{portmap['D0']}_IOL"
+            # XXX implement ODDR with TBUF
+            oddr.portmap['Q1'] = ""
             #oddr.portmap['Q1'] = f"R{row}C{col}_{portmap['Q1']}_IOL"
             mod.wires.update(oddr.portmap.values())
             mod.primitives[name] = oddr


### PR DESCRIPTION
Gowin tools do not understand dimensionless constant assignments and,
oddly enough, binary constants in the INIT parameter. So we specify the
dimensionality in the first case and use the hexadecimal representation
in the second.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>