### PR TITLE
packer: generalization of ignored cell types

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -30,6 +30,8 @@ def get_bels(data):
     later = []
     belre = re.compile(r"R(\d+)C(\d+)_(?:GSR|SLICE|IOB|MUX2_LUT5|MUX2_LUT6|MUX2_LUT7|MUX2_LUT8|ODDR|OSC[ZFH]?|BUFS|RAMW)(\w*)")
     for cellname, cell in data['modules']['top']['cells'].items():
+        if cell['type'].startswith('DUMMY_') :
+            continue
         bel = cell['attributes']['NEXTPNR_BEL']
         if bel in {"VCC", "GND"}: continue
         bels = belre.match(bel)
@@ -90,6 +92,8 @@ def place(db, tilemap, bels, cst, args):
         tiledata = db.grid[row-1][col-1]
         tile = tilemap[(row-1, col-1)]
         if typ == "GSR":
+            pass
+        elif typ.startswith('MUX2_'):
             pass
         elif typ == "BUFS":
             # fuses must be reset in order to activate so remove them


### PR DESCRIPTION
* Experiments with specialized routers can lead (in intermediate
  branches they already do) to the use of fake cell types, which are not
  encoded in any way, but only used to create the desired sequence of
  PIPs. To avoid adding a lot of ignored types, it is proposed to ignore
  types starting with DUMMY_.
* Removed swearing on the unknown type MUX2_, but the type itself is
  left for the reason that although no action is required from the
  packer, it is still a real cell type.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>