### PR TITLE
Add a check on the use of dangerous pins

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -80,6 +80,7 @@ class Device:
     packages: Dict[str, Tuple[str, str, str]] = field(default_factory=dict)
     pinout: Dict[str, Dict[str, Dict[str, str]]] = field(default_factory=dict)
     pin_bank: Dict[str, int] = field(default_factory = dict)
+    dangerous_pins: Dict[str, Tuple[str, int]] = field(default_factory=dict)
     cmd_hdr: List[ByteString] = field(default_factory=list)
     cmd_ftr: List[ByteString] = field(default_factory=list)
     template: np.ndarray = None
@@ -373,26 +374,38 @@ def get_pins(device):
         res_bank_pins.update(pindef.get_bank_pins(device, pkg))
     return (pkgs, res, res_bank_pins)
 
+#
+def get_dangerous_pins(device, pkgs):
+    for pkg in pkgs.values():
+        dangerous_pins = pindef.get_dangerous_locs(device, pkg[0])
+        if dangerous_pins:
+            break
+    return dangerous_pins
+
 # returns ({partnumber: (package, device, speed)}, {pins}, {bank_pins})
 def json_pinout(device):
     if device == "GW1N-1":
         pkgs, pins, bank_pins = get_pins("GW1N-1")
+        dangerous_pins = get_dangerous_pins(device, pkgs)
         return (pkgs, {
             "GW1N-1": pins
-        }, bank_pins)
+        }, bank_pins, dangerous_pins)
     elif device == "GW1NZ-1":
         pkgs, pins, bank_pins = get_pins("GW1NZ-1")
+        dangerous_pins = get_dangerous_pins(device, pkgs)
         return (pkgs, {
             "GW1NZ-1": pins
-        }, bank_pins)
+        }, bank_pins, dangerous_pins)
     elif device == "GW1N-4":
         pkgs, pins, bank_pins = get_pins("GW1N-4")
+        dangerous_pins = get_dangerous_pins(device, pkgs)
         return (pkgs, {
             "GW1N-4": pins
-        }, bank_pins)
+        }, bank_pins, dangerous_pins)
     elif device == "GW1NS-4":
         pkgs_sr, pins_sr, bank_pins_sr = get_pins("GW1NSR-4C")
         pkgs, pins, bank_pins = get_pins("GW1NS-4")
+        dangerous_pins = get_dangerous_pins(device, pkgs)
         res = {}
         res.update(pkgs)
         res.update(pkgs_sr)
@@ -402,9 +415,10 @@ def json_pinout(device):
         return (res, {
             "GW1NS-4": pins,
             "GW1NSR-4C": pins_sr
-        }, res_bank_pins)
+        }, res_bank_pins, dangerous_pins)
     elif device == "GW1N-9":
         pkgs, pins, bank_pins = get_pins("GW1N-9")
+        dangerous_pins = get_dangerous_pins(device, pkgs)
         pkgs_r, pins_r, bank_pins_r = get_pins("GW1NR-9")
         res = {}
         res.update(pkgs)
@@ -415,9 +429,10 @@ def json_pinout(device):
         return (res, {
             "GW1N-9": pins,
             "GW1NR-9": pins_r
-        }, res_bank_pins)
+        }, res_bank_pins, dangerous_pins)
     elif device == "GW1N-9C":
         pkgs, pins, bank_pins = get_pins("GW1N-9C")
+        dangerous_pins = get_dangerous_pins(device, pkgs)
         pkgs_r, pins_r, bank_pins_r = get_pins("GW1NR-9C")
         res = {}
         res.update(pkgs)
@@ -428,9 +443,10 @@ def json_pinout(device):
         return (res, {
             "GW1N-9C": pins,
             "GW1NR-9C": pins_r
-        }, res_bank_pins)
+        }, res_bank_pins, dangerous_pins)
     elif device == "GW1NS-2":
         pkgs, pins, bank_pins = get_pins("GW1NS-2")
+        dangerous_pins = get_dangerous_pins(device, pkgs)
         pkgs_c, pins_c, bank_pins_c = get_pins("GW1NS-2C")
         res = {}
         res.update(pkgs)
@@ -441,7 +457,7 @@ def json_pinout(device):
         return (res, {
             "GW1NS-2": pins,
             "GW1NS-2C": pins_c
-        }, res_bank_pins)
+        }, res_bank_pins, dangerous_pins)
     else:
         raise Exception("unsupported device")
 

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -159,7 +159,14 @@ def place(db, tilemap, bels, cst, args):
             elif col == db.cols:
                 edge = 'R'
                 idx = row
-            cst.ports[cellname] = f"IO{edge}{idx}{num}"
+            bel_loc = f"IO{edge}{idx}{num}"
+            if bel_loc in db.dangerous_pins.keys():
+                if what_to_do == 0:
+                    exit(f"It is forbidden to use a {pin_name} pin ({bel_loc}) as a GPIO.")
+                else:
+                    print(f"WARNING: {pin_name} pin ({bel_loc}) used as a GPIO!")
+
+            cst.ports[cellname] = bel_loc
             iob = tiledata.bels[f'IOB{num}']
             if 'DIFF' in attrs.keys():
                 mode = attrs['DIFF_TYPE']

--- a/apycula/pindef.py
+++ b/apycula/pindef.py
@@ -93,6 +93,16 @@ def get_clock_locs(device, package):
     return [(pin['NAME'], *pin['CFG'].split('/')) for pin in df
             if 'CFG' in pin.keys() and pin['CFG'].startswith("GCLK")]
 
+# { location : (pin_name, what-to-do)}
+def get_dangerous_locs(device, package):
+    df = get_package(device, package, True)
+    # return 0 (stop) for now
+    res = {}
+    spec_pins = [p for p in df if 'CFG' in p.keys() and p['CFG'].startswith('MODE')]
+    for pin in spec_pins:
+        res.update({pin['NAME'] : (pin['CFG'].split('/')[0], 0)})
+    return res
+
 # { name : (is_diff, is_true_lvds, is_positive)}
 def get_diff_cap_info(device, package, special_pins=False):
     df = get_package(device, package, special_pins)

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -923,7 +923,7 @@ if __name__ == "__main__":
     db = chipdb.from_fse(device, fse)
     chipdb.set_banks(device, db)
     db.timing = tm
-    db.packages, db.pinout, db.pin_bank = chipdb.json_pinout(device)
+    db.packages, db.pinout, db.pin_bank, db.dangerous_pins = chipdb.json_pinout(device)
 
     corners = [
         (0, 0, fse['header']['grid'][61][0][0]),


### PR DESCRIPTION
gowin_pack terminates if it detects the use of dangerous pins as GPIOs.
There is no command line key that allows the use: it is assumed that in
case of emergency one can make changes in gowin_pack, being
fully aware of the consequences.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>