### PR TITLE
Make less dependencies required

### DIFF
--- a/.github/workflows/chipdb.yml
+++ b/.github/workflows/chipdb.yml
@@ -178,7 +178,7 @@ jobs:
         name: gw1ns-4-chipdb
         path: apycula
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Install and build
@@ -216,7 +216,7 @@ jobs:
         name: python-dist
         path: dist
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Install and build

--- a/.github/workflows/chipdb.yml
+++ b/.github/workflows/chipdb.yml
@@ -14,126 +14,126 @@ jobs:
   gw1n1:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build gw1n-1 chipdb
       run: |
         docker pull pepijndevos/apicula:1.9.8
         docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW1N-1.pickle
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-1-chipdb
           path: apycula/GW1N-1.pickle
     - name: Archive stage artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-1-stage
           path: GW1N-1*
   gw1nz1:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build gw1nz-1 chipdb
       run: |
         docker pull pepijndevos/apicula:1.9.8
         docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW1NZ-1.pickle
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1nz-1-chipdb
           path: apycula/GW1NZ-1.pickle
     - name: Archive stage artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1nz-1-stage
           path: GW1NZ-1*
   gw1n9:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build gw1n-9 chipdb
       run: |
         docker pull pepijndevos/apicula:1.9.8
         docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW1N-9.pickle
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-9-chipdb
           path: apycula/GW1N-9.pickle
     - name: Archive stage artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-9-stage
           path: GW1N-9*
   gw1n9c:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build gw1n-9c chipdb
       run: |
         docker pull pepijndevos/apicula:1.9.8
         docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW1N-9C.pickle
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-9c-chipdb
           path: apycula/GW1N-9C.pickle
     - name: Archive stage artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-9c-stage
           path: GW1N-9C*
   gw1n4:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build gw1n-4 chipdb
       run: |
         docker pull pepijndevos/apicula:1.9.8
         docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW1N-4.pickle
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-4-chipdb
           path: apycula/GW1N-4.pickle
     - name: Archive stage artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1n-4-stage
           path: GW1N-4*
   gw1ns2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build gw1ns-2 chipdb
       run: |
         docker pull pepijndevos/apicula:1.9.8
         docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW1NS-2.pickle
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1ns-2-chipdb
           path: apycula/GW1NS-2.pickle
     - name: Archive stage artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1ns-2-stage
           path: GW1NS-2*
   gw1ns4:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build gw1ns-4 chipdb
       run: |
         docker pull pepijndevos/apicula:1.9.8
         docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW1NS-4.pickle
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1ns-4-chipdb
           path: apycula/GW1NS-4.pickle
     - name: Archive stage artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: gw1ns-4-stage
           path: GW1NS-4*
@@ -141,44 +141,44 @@ jobs:
     runs-on: ubuntu-latest
     needs: [gw1n1, gw1nz1, gw1n9, gw1n9c, gw1n4, gw1ns2, gw1ns4]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download gw1n-1 chipdb
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gw1n-1-chipdb
         path: apycula
     - name: Download gw1nz-1 chipdb
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gw1nz-1-chipdb
         path: apycula
     - name: Download gw1n-4 chipdb
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gw1n-4-chipdb
         path: apycula
     - name: Download gw1n-9 chipdb
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gw1n-9-chipdb
         path: apycula
     - name: Download gw1n-9c chipdb
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gw1n-9c-chipdb
         path: apycula
     - name: Download gw1ns-2 chipdb
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gw1ns-2-chipdb
         path: apycula
     - name: Download gw1ns-4 chipdb
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: gw1ns-4-chipdb
         path: apycula
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.8'
     - name: Install and build
@@ -188,7 +188,7 @@ jobs:
         python setup.py --version
         python setup.py sdist bdist_wheel
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: python-dist
           path: dist
@@ -209,14 +209,14 @@ jobs:
         yosys: [master, yosys-0.20]
         nextpnr: [master, nextpnr-0.3]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download python package
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: python-dist
         path: dist
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.9'
     - name: Install and build
@@ -245,7 +245,7 @@ jobs:
         cd ../examples
         make -j$(nproc) all
     - name: Archive artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: examples-${{ matrix.yosys }}-${{ matrix.nextpnr }}
           path: examples

--- a/.github/workflows/yowasp_examples.yml
+++ b/.github/workflows/yowasp_examples.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: '3.9'
       - name: Display Python version
@@ -27,7 +27,7 @@ jobs:
           cd examples
           YOSYS=yowasp-yosys NEXTPNR=yowasp-nextpnr-gowin make all
       - name: Archive artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
             name: bitstreams
             path: examples/*.fs

--- a/.github/workflows/yowasp_examples.yml
+++ b/.github/workflows/yowasp_examples.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - name: Display Python version

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p "/root/Documents/gowinsemi/" && \
 	curl -so "/root/Documents/gowinsemi/GW1NS-2C Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG825-1.2.1E_GW1NS-2C%20Pinout.xlsx" && \
 	curl -so "/root/Documents/gowinsemi/GW1NS-2 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG822-1.2.1E_GW1NS-2%20Pinout.xlsx"
 
-RUN pip install --no-cache-dir numpy crcmod openpyxl
+RUN pip install --no-cache-dir numpy crcmod
 
 WORKDIR /usr/src/apicula
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p "/root/Documents/gowinsemi/" && \
 	curl -so "/root/Documents/gowinsemi/GW1NS-2C Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG825-1.2.1E_GW1NS-2C%20Pinout.xlsx" && \
 	curl -so "/root/Documents/gowinsemi/GW1NS-2 Pinout.xlsx" "https://wishfulcoding.nl/gowin/UG822-1.2.1E_GW1NS-2%20Pinout.xlsx"
 
-RUN pip install --no-cache-dir numpy pillow crcmod openpyxl
+RUN pip install --no-cache-dir numpy crcmod openpyxl
 
 WORKDIR /usr/src/apicula
 

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -1,6 +1,5 @@
 from math import ceil
 import numpy as np
-from PIL import Image
 from crcmod.predefined import mkPredefinedCrcFun
 
 crc16arc = mkPredefinedCrcFun('crc-16')
@@ -126,6 +125,7 @@ def write_bitstream(fname, bs, hdr, ftr, compress):
 
 
 def display(fname, data):
+    from PIL import Image
     im = Image.frombytes(
             mode='1',
             size=data.shape[::-1],

--- a/apycula/clock_fuzzer.py
+++ b/apycula/clock_fuzzer.py
@@ -1,17 +1,14 @@
 from multiprocessing.dummy import Pool
-from PIL import Image
-import numpy as np
 import pickle
 import json
 import re
 from apycula import tiled_fuzzer
 from apycula import codegen
 from apycula import pindef
-from apycula import bslib
 from apycula import chipdb
 from apycula import fuse_h4x
 from apycula import gowin_unpack
-from apycula.wirenames import wirenames, clknames, wirenumbers, clknumbers
+from apycula.wirenames import clknumbers
 
 def dff(mod, cst, row, col, clk=None):
     "make a dff with optional clock"

--- a/apycula/fuse_h4x.py
+++ b/apycula/fuse_h4x.py
@@ -1,6 +1,5 @@
 import sys
 import numpy as np
-from PIL import Image
 import random
 
 def rint(f, w):
@@ -122,6 +121,7 @@ def render_bitmap(d):
     return bitmap
 
 def display(fname, data):
+    from PIL import Image
     im = Image.frombytes(
             mode='P',
             size=data.shape[::-1],

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -359,6 +359,11 @@ def dualmode_pins(db, tilemap, args):
             tile[row][col] = 1
 
 def main():
+    pil_available = True
+    try:
+        from PIL import Image
+    except ImportError:
+        pil_available = False
     parser = argparse.ArgumentParser(description='Pack Gowin bitstream')
     parser.add_argument('netlist')
     parser.add_argument('-d', '--device', required=True)
@@ -372,7 +377,8 @@ def main():
     parser.add_argument('--ready_as_gpio', action = 'store_true')
     parser.add_argument('--done_as_gpio', action = 'store_true')
     parser.add_argument('--reconfign_as_gpio', action = 'store_true')
-    parser.add_argument('--png')
+    if pil_available:
+        parser.add_argument('--png')
 
     args = parser.parse_args()
     device = args.device
@@ -397,7 +403,7 @@ def main():
     dualmode_pins(db, tilemap, args)
     res = chipdb.fuse_bitmap(db, tilemap)
     header_footer(db, res, args.compress)
-    if args.png:
+    if pil_available and args.png:
         bslib.display(args.png, res)
     bslib.write_bitstream(args.output, res, db.cmd_hdr, db.cmd_ftr, args.compress)
     if args.cst:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'crcmod',
-        'openpyxl',
     ],
     python_requires='>=3.6',
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ setuptools.setup(
     ],
     install_requires=[
         'numpy',
-        'pandas',
-        'pillow',
         'crcmod',
         'openpyxl',
     ],


### PR DESCRIPTION
To make apicula available in oss-cad-suite build I needed to make sure all python libraries are delivered as well, and there is problem building `pillow` in cross compile environment, also `pandas` was not used at all (and was causing some problems when doing cross compilation as well). 
Since `-png` option is anyway only for development, I just made sure it is available only if `pillow` is installed.