### PR TITLE
Fix the creation of implicit clock wires

### DIFF
--- a/apycula/clock_fuzzer.py
+++ b/apycula/clock_fuzzer.py
@@ -267,7 +267,7 @@ def spine_aliases(quads, dests, clks):
 def add_rim(rows, cols, spine_row):
     if 1 in rows:
         rows.add(0)
-    if max(rows) > spine_row:
+    if max(rows) > spine_row and spine_row != 1:
         rows.update({row for row in range(max(rows) + 1, db.rows)})
     if 1 in cols:
         cols.add(0)


### PR DESCRIPTION
Corrects a mistake where non-existent wires were created for chips with 4 quadrants.

Fix https://github.com/YosysHQ/apicula/issues/143

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>