### PR TITLE
Don't create GTx aliases along the central column

### DIFF
--- a/apycula/clock_fuzzer.py
+++ b/apycula/clock_fuzzer.py
@@ -280,6 +280,8 @@ def tap_aliases(quads):
     for _, (rows, cols, spine_row) in quads.items():
         add_rim(rows, cols, spine_row)
         for col in cols:
+            if col == dat['center'][1] - 1:
+                continue
             for row in rows:
                 for src in ["GT00", "GT10"]:
                     if row != spine_row:


### PR DESCRIPTION
These cells are served by the closest tap on the west side (according to GBx0 clock wire number) and clock fuzzer finds this perfectly, no GTx0 wires are used in the central column.

This did not cause errors, just no need to create wires leading nowhere and waste routing time.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>