### PR TITLE
Add the alonenode mechanism

### DIFF
--- a/apycula/clock_fuzzer.py
+++ b/apycula/clock_fuzzer.py
@@ -317,55 +317,6 @@ def get_bufs_bits(fse, ttyp, win, wout):
 
 # create aliases and pips for long wires
 def make_lw_aliases(fse, dat, db, quads, clks):
-    # type 81, 82, 83, 84 tiles have source muxes
-    center_row, col82 = dat['center']
-    center_row -= 1
-    last_row = db.rows - 1
-    col82 -= 1
-    col81 = col82 - 1
-    col83 = col82 + 1
-    col84 = col82 + 2
-    # type 91 and 92 tiles activate the quadrants
-    # XXX GW1NS-4 have different types
-    type91 = fse['header']['grid'][61][0][col82]
-    type92 = fse['header']['grid'][61][last_row][col82]
-    col91 = col82
-    has_bottom_quadrants = len(quads) > 2
-
-    # quadrants activation bels
-    # delete direct pips "long wire->spine" because the artificial bel will be used,
-    # which replaces this direct pip
-    rows = {(0, 'T', type91)}
-    if has_bottom_quadrants:
-        rows.update({ (last_row, 'B', type92) })
-    for row, half, ttyp in rows:
-        for idx in range(8):
-            bel = db.grid[row][col91].bels.setdefault(f'BUFS{idx}', chipdb.Bel())
-            del db.grid[row][col91].clock_pips[f'LWSPINE{half}L{idx}']
-            del db.grid[row][col91].clock_pips[f'LWSPINE{half}R{idx}']
-            src = f'LW{half}{idx}'
-            db.grid[row][col91].clock_pips.setdefault(f'LWI{idx}', {})[src] = {}
-            db.grid[row][col91].clock_pips.setdefault(f'LWSPINE{half}L{idx}', {})[f'LWO{idx}'] = {}
-            bel.flags['L'] = get_bufs_bits(fse, ttyp, f'LW{half}{idx}', f'LWSPINE{half}L{idx}')
-            db.grid[row][col91].clock_pips.setdefault(f'LWSPINE{half}R{idx}', {})[f'LWO{idx}'] = {}
-            bel.flags['R'] = get_bufs_bits(fse, ttyp, f'LW{half}{idx}', f'LWSPINE{half}R{idx}')
-            bel.portmap['I'] = f'LWI{idx}'
-            bel.portmap['O'] = f'LWO{idx}'
-            # aliases for long wire origins (center muxes)
-            # If we have only two quadrants, then do not create aliases in the bottom tile 92,
-            # thereby excluding these wires from the candidates for routing
-            if half == 'B' and not has_bottom_quadrants:
-                continue
-            if half == 'T':
-                if idx != 7:
-                    db.aliases.update({(row, col82, src) : (center_row, col82, src)})
-                else:
-                    db.aliases.update({(row, col82, src) : (center_row, col81, src)})
-            else:
-                if idx != 7:
-                    db.aliases.update({(row, col82, src) : (center_row, col83, src)})
-                else:
-                    db.aliases.update({(row, col82, src) : (center_row, col84, src)})
     # branches
     # {lw#: {tap_col: {cols}}
     taps = {}
@@ -395,49 +346,9 @@ def make_lw_aliases(fse, dat, db, quads, clks):
     for row in range(db.rows):
         for lw, tap_desc in taps.items():
             for tap_col, cols in tap_desc.items():
-                tap_row = 0
-                if row > (center_row * 2) and has_bottom_quadrants:
-                    tap_row = last_row
-                db.aliases.update({(row, tap_col, 'LT01') : (tap_row, tap_col, 'LT02')})
-                db.aliases.update({(row, tap_col, 'LT04') : (tap_row, tap_col, 'LT13')})
                 for col in cols:
                     db.aliases.update({(row, col, f'LB{lw}1') : (row, tap_col, f'LBO0')})
                     db.aliases.update({(row, col, f'LB{lw + 4}1') : (row, tap_col, f'LBO1')})
-
-    # tap sources
-    rows = { (0, 'T') }
-    if has_bottom_quadrants:
-        rows.update({ (last_row, 'B') })
-    else:
-        for tp in ['LT02', 'LT13']:
-            del db.grid[last_row][tap_col].pips[tp]
-
-    for row, qd in rows:
-        for lw, tap_desc in taps.items():
-            for tap_col, cols in tap_desc.items():
-                if tap_col <= col91:
-                    half = 'L'
-                else:
-                    half = 'R'
-                db.aliases.update({ (row, tap_col, 'SS00') : (row, col91, f'LWSPINE{qd}{half}{lw}') })
-                db.aliases.update({ (row, tap_col, 'SS40') : (row, col91, f'LWSPINE{qd}{half}{lw + 4}') })
-                # XXX remove all pips except SS00 and SS40
-                pip2keep = {'SS00', 'SS40'}
-                for tp in ['LT02', 'LT13']:
-                    for pip in [p for p in db.grid[row][tap_col].pips[tp] if p not in pip2keep]:
-                        del db.grid[row][tap_col].pips[tp][pip]
-
-    # logic entries
-    srcs = {}
-    for i, src in dat['CmuxIns'].items():
-        row, col, pip = src
-        if pip == 126: # CLK2
-            idx = int(i)
-            db.aliases.update({ (center_row, col82, f'UNK{idx + 80}'): (row - 1, col -1, 'CLK2')})
-            db.aliases.update({ (center_row, col81, f'UNK{idx + 80}'): (row - 1, col -1, 'CLK2')})
-            if has_bottom_quadrants:
-                db.aliases.update({ (center_row, col83, f'UNK{idx + 80}'): (row - 1, col -1, 'CLK2')})
-                db.aliases.update({ (center_row, col84, f'UNK{idx + 80}'): (row - 1, col -1, 'CLK2')})
 
 if __name__ == "__main__":
     quads = quadrants()

--- a/apycula/wirenames.py
+++ b/apycula/wirenames.py
@@ -25,8 +25,10 @@ wirenames = { 0: "A0", 1: "B0", 2: "C0", 3: "D0", 4: "A1", 5: "B1", 6: "C1", 7: 
 303: "CIN0", 304: "CIN1", 305: "CIN2", 306: "CIN3", 307: "CIN4", 308: "CIN5", 309: "COUT0", 310: "COUT1", 311: "COUT2", 312: "COUT3", 313: "COUT4", 314: "COUT5"}
 wirenames.update({n: f"LWSPINETL{n - 1001}" for n in range(1001, 1009)})
 wirenames.update({n: f"LWSPINETR{n - 1009}" for n in range(1009, 1017)})
-wirenames.update({n: f"LWSPINEBL{n - 1033}" for n in range(1033, 1041)})
-wirenames.update({n: f"LWSPINEBR{n - 1041}" for n in range(1041, 1049)})
+wirenames.update({n: f"LWSPINEBL{n - 1017}" for n in range(1017, 1025)})
+wirenames.update({n: f"LWSPINEBR{n - 1025}" for n in range(1025, 1033)})
+wirenames.update({n: f"LWSPINEB1L{n - 1033}" for n in range(1033, 1041)})
+wirenames.update({n: f"LWSPINEB1R{n - 1041}" for n in range(1041, 1049)})
 
 wirenumbers = {v: k for k, v in wirenames.items()}
 


### PR DESCRIPTION
Storing and using part of the "alonenode" table to set fuses designed to disable "lone" nodes, i.e. nodes that are not used as sources. It is used to switch long wires in buses.

In addition, the representation of long wires is greatly simplified by creating only the necessary aliases and transferring the main work to the nextpnr.

It should be noted that only table #6 of the "alonenode" family is involved, since the function of table #69 remains unclear.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>