### PR TITLE
Replace DFF fuzzer with table data

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -206,7 +206,7 @@ def add_alu_mode(base_mode, modes, lut, new_alu_mode, new_mode_bits):
         if bit == '0':
             alu_mode.update(lut.flags[15 - i])
 
-# also make ALUs and shadow RAM
+# also make DFFs, ALUs and shadow RAM
 def fse_luts(fse, ttyp):
     data = fse[ttyp]['shortval'][5]
 
@@ -234,6 +234,17 @@ def fse_luts(fse, ttyp):
         except KeyError:
             continue
         for i in range(2):
+            # DFF
+            bel = luts.setdefault(f"DFF{cls * 2 + i}", Bel())
+            bel.portmap = {
+                # D inputs hardwired to LUT F
+                'Q'  : f"Q{cls * 2 + i}",
+                'CLK': f"CLK{cls}",
+                'LSR': f"LSR{cls}", # set/reset
+                'CE' : f"CE{cls}", # clock enable
+            }
+
+            # ALU
             alu_idx = cls * 2 + i
             bel = luts.setdefault(f"ALU{alu_idx}", Bel())
             mode = set()
@@ -805,27 +816,6 @@ def shared2flag(dev):
                             if mode_cb:
                                 belb.flags[mode+"C"] = mode_cb
                                 bits -= mode_cb
-
-def dff_clean(dev):
-    """ Clean DFF mode bits: fuzzer captures a bit of the neighboring trigger."""
-    seen_bels = []
-    for idx, row in enumerate(dev.grid):
-        for jdx, td in enumerate(row):
-            for name, bel in td.bels.items():
-                if name[0:3] == "DFF":
-                    if bel in seen_bels:
-                        continue
-                    seen_bels.append(bel)
-                    # find extra bit
-                    extra_bits = None
-                    for bits in bel.modes.values():
-                        if extra_bits != None:
-                            extra_bits &= bits
-                        else:
-                            extra_bits = bits.copy()
-                    # remove it
-                    for mode, bits in bel.modes.items():
-                        bits -= extra_bits
 
 def get_route_bits(db, row, col):
     """ All routing bits for the cell """

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -407,6 +407,8 @@ def place(db, tilemap, bels, cst, args):
                 # invert clock?
                 if mode in {'DFFN', 'DFFNR', 'DFFNC', 'DFFNP', 'DFFNS'}:
                     add_attr_val(db, 'SLICE', dff_attrs, cls_attrids['CLKMUX_CLK'], cls_attrvals['INV'])
+                else:
+                    add_attr_val(db, 'SLICE', dff_attrs, cls_attrids['CLKMUX_CLK'], cls_attrvals['SIG'])
 
                 # async option?
                 if mode in {'DFFNC', 'DFFNP', 'DFFC', 'DFFP'}:

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -399,7 +399,7 @@ def place(db, tilemap, bels, cst, args):
                 # REG0_REGSET and REG1_REGSET select set/reset or preset/clear options for each DFF individually
                 if mode in {'DFFR', 'DFFC', 'DFFNR', 'DFFNC'}:
                     add_attr_val(db, 'SLICE', dff_attrs, cls_attrids[f'REG{int(num) % 2}_REGSET'], cls_attrvals['RESET'])
-                else:
+                elif mode not in {'DFF', 'DFFN'}:
                     add_attr_val(db, 'SLICE', dff_attrs, cls_attrids[f'REG{int(num) % 2}_REGSET'], cls_attrvals['SET'])
                 # are set/reset/clear/preset port needed?
                 if mode not in {'DFF', 'DFFN'}:
@@ -413,6 +413,7 @@ def place(db, tilemap, bels, cst, args):
                     add_attr_val(db, 'SLICE', dff_attrs, cls_attrids['SRMODE'], cls_attrvals['ASYNC'])
 
                 dffbits = get_shortval_fuses(db, tiledata.ttyp, dff_attrs, f'CLS{int(num) // 2}')
+                #print(f'({row - 1}, {col - 1}) mode:{mode}, num{num}, attrs:{dff_attrs}, bits:{dffbits}')
                 for brow, bcol in dffbits:
                     tile[brow][bcol] = 1
 

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -9,7 +9,7 @@ import argparse
 import importlib.resources
 from apycula import codegen
 from apycula import chipdb
-from apycula.attrids import pll_attrids, pll_attrvals
+from apycula.attrids import pll_attrids, pll_attrvals, cls_attrids, cls_attrvals
 from apycula.bslib import read_bitstream
 from apycula.wirenames import wirenames
 
@@ -111,6 +111,48 @@ def pll_attrs_refine(in_attrs):
         res.add(f'{attr}={new_val}')
     return res
 
+
+# {(REGSET, LSRONMUX, CLKMUX_CLK, SRMODE) : dff_type}
+_dff_types = {
+   ('RESET', '',       'SIG', '') :      'DFF',
+   ('RESET', '',       'INV', '') :      'DFFN',
+   ('RESET', 'LSRMUX', 'SIG', 'ASYNC') : 'DFFC',
+   ('RESET', 'LSRMUX', 'INV', 'ASYNC') : 'DFFNC',
+   ('RESET', 'LSRMUX', 'SIG', '') :      'DFFR',
+   ('RESET', 'LSRMUX', 'INV', '') :      'DFFNR',
+   ('SET',   'LSRMUX', 'SIG', 'ASYNC') : 'DFFP',
+   ('SET',   'LSRMUX', 'INV', 'ASYNC') : 'DFFNP',
+   ('SET',   'LSRMUX', 'SIG', '') :      'DFFS',
+   ('SET',   'LSRMUX', 'INV', '') :      'DFFNS',
+}
+
+def get_dff_type(dff_idx, in_attrs):
+    def get_attrval_name(val):
+        for nam, vl in cls_attrvals.items():
+            if vl == val:
+                return nam
+        return None
+
+    attrs = {}
+    if 'LSRONMUX' in in_attrs.keys():
+        attrs['LSRONMUX'] = get_attrval_name(in_attrs['LSRONMUX'])
+    else:
+        attrs['LSRONMUX'] = ''
+    if 'CLKMUX_CLK' in in_attrs.keys():
+        attrs['CLKMUX_CLK'] = get_attrval_name(in_attrs['CLKMUX_CLK'])
+    else:
+        attrs['CLKMUX_CLK'] = 'SIG'
+    if 'SRMODE' in in_attrs.keys():
+        attrs['SRMODE'] = get_attrval_name(in_attrs['SRMODE'])
+    else:
+        attrs['SRMODE'] = ''
+    if f'REG{dff_idx % 2}_REGSET' in in_attrs.keys():
+        attrs['REGSET'] = get_attrval_name(in_attrs[f'REG{dff_idx % 2}_REGSET'])
+    else:
+        attrs['REGSET'] = 'SET'
+
+    return _dff_types.get((attrs['REGSET'], attrs['LSRONMUX'], attrs['CLKMUX_CLK'], attrs['SRMODE']))
+
 # parse attributes and values use 'logicinfo' table
 # returns {attr: value}
 # attribute names are decoded with the attribute table, but the values are returned in raw form
@@ -134,7 +176,7 @@ def parse_attrvals(tile, logicinfo_table, fuse_table, attrname_table):
         else:
             set_mask.update(bits)
     set_bits =  {(row, col) for row, col in set_mask if tile[row][col] == 1}
-    zero_bits = {(row, col) for row, col in set_mask if tile[row][col] == 0}
+    zero_bits = {(row, col) for row, col in zero_mask if tile[row][col] == 0}
     # find candidates from fuse table
     attrvals = set()
     for raw_bits, test_fn in [(zero_bits, is_neg_key), (set_bits, is_pos_key)]:
@@ -201,6 +243,16 @@ def parse_tile_(db, row, col, tile, default=True, noalias=False, noiostd = True)
                 modes.add(attrval)
             if modes:
                 bels[f'{name}{idx}'] = modes
+            continue
+        if name.startswith("DFF"):
+            idx = int(name[3])
+            attrvals = parse_attrvals(tile, db.logicinfo['SLICE'], db.shortval[tiledata.ttyp][f'CLS{idx // 2}'], cls_attrids)
+            # skip ALU and unsupported modes
+            if attrvals.get('MODE') == cls_attrvals['ALU'] or attrvals.get('REGMODE') == cls_attrvals['LATCH'] or attrvals.get('MODE') == cls_attrvals['SSRAM']:
+                continue
+            dff_type = get_dff_type(idx, attrvals)
+            if dff_type:
+                bels[f'{name}'] = {dff_type}
             continue
         if name.startswith("IOB"):
             #print(name)

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -114,16 +114,16 @@ def pll_attrs_refine(in_attrs):
 
 # {(REGSET, LSRONMUX, CLKMUX_CLK, SRMODE) : dff_type}
 _dff_types = {
-   ('RESET', '',       'SIG', '') :      'DFF',
-   ('RESET', '',       'INV', '') :      'DFFN',
-   ('RESET', 'LSRMUX', 'SIG', 'ASYNC') : 'DFFC',
-   ('RESET', 'LSRMUX', 'INV', 'ASYNC') : 'DFFNC',
-   ('RESET', 'LSRMUX', 'SIG', '') :      'DFFR',
-   ('RESET', 'LSRMUX', 'INV', '') :      'DFFNR',
-   ('SET',   'LSRMUX', 'SIG', 'ASYNC') : 'DFFP',
-   ('SET',   'LSRMUX', 'INV', 'ASYNC') : 'DFFNP',
-   ('SET',   'LSRMUX', 'SIG', '') :      'DFFS',
-   ('SET',   'LSRMUX', 'INV', '') :      'DFFNS',
+   ('RESET', 'LSRMUX', 'SIG', '') :      'DFF',
+   ('RESET', 'LSRMUX', 'INV', '') :      'DFFN',
+   ('RESET', '',       'SIG', 'ASYNC') : 'DFFC',
+   ('RESET', '',       'INV', 'ASYNC') : 'DFFNC',
+   ('RESET', '',       'SIG', '') :      'DFFR',
+   ('RESET', '',       'INV', '') :      'DFFNR',
+   ('SET',   '',       'SIG', 'ASYNC') : 'DFFP',
+   ('SET',   '',       'INV', 'ASYNC') : 'DFFNP',
+   ('SET',   '',       'SIG', '') :      'DFFS',
+   ('SET',   '',       'INV', '') :      'DFFNS',
 }
 
 def get_dff_type(dff_idx, in_attrs):
@@ -149,7 +149,7 @@ def get_dff_type(dff_idx, in_attrs):
     if f'REG{dff_idx % 2}_REGSET' in in_attrs.keys():
         attrs['REGSET'] = get_attrval_name(in_attrs[f'REG{dff_idx % 2}_REGSET'])
     else:
-        attrs['REGSET'] = 'SET'
+        attrs['REGSET'] = 'RESET'
 
     return _dff_types.get((attrs['REGSET'], attrs['LSRONMUX'], attrs['CLKMUX_CLK'], attrs['SRMODE']))
 
@@ -176,7 +176,7 @@ def parse_attrvals(tile, logicinfo_table, fuse_table, attrname_table):
         else:
             set_mask.update(bits)
     set_bits =  {(row, col) for row, col in set_mask if tile[row][col] == 1}
-    zero_bits = {(row, col) for row, col in zero_mask if tile[row][col] == 0}
+    zero_bits = {(row, col) for row, col in zero_mask if tile[row][col] == 1}
     # find candidates from fuse table
     attrvals = set()
     for raw_bits, test_fn in [(zero_bits, is_neg_key), (set_bits, is_pos_key)]:
@@ -248,7 +248,7 @@ def parse_tile_(db, row, col, tile, default=True, noalias=False, noiostd = True)
             idx = int(name[3])
             attrvals = parse_attrvals(tile, db.logicinfo['SLICE'], db.shortval[tiledata.ttyp][f'CLS{idx // 2}'], cls_attrids)
             # skip ALU and unsupported modes
-            if attrvals.get('MODE') == cls_attrvals['ALU'] or attrvals.get('REGMODE') == cls_attrvals['LATCH'] or attrvals.get('MODE') == cls_attrvals['SSRAM']:
+            if attrvals.get('REGMODE') == cls_attrvals['LATCH'] or attrvals.get('MODE') == cls_attrvals['SSRAM']:
                 continue
             dff_type = get_dff_type(idx, attrvals)
             if dff_type:


### PR DESCRIPTION
DFFs are assembled from parts depending on the type, also when unpacking the type is reconstructed from the used functional parts, which means "clock line inversion", "asynchrony", "triggering by SET or RESET", etc.

Signed-off-by: YRabbit <rabbit@yrabbit.cyou>