### PR TITLE
Add support for the GW2A series 

### DIFF
--- a/.github/workflows/chipdb.yml
+++ b/.github/workflows/chipdb.yml
@@ -137,9 +137,27 @@ jobs:
       with:
           name: gw1ns-4-stage
           path: GW1NS-4*
+  gw2a18:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build gw2a-18 chipdb
+      run: |
+        docker pull pepijndevos/apicula:1.9.8
+        docker run -v $(pwd):/usr/src/apicula pepijndevos/apicula:1.9.8 make apycula/GW2A-18.pickle
+    - name: Archive artifact
+      uses: actions/upload-artifact@v3
+      with:
+          name: gw2a-18-chipdb
+          path: apycula/GW2A-18.pickle
+    - name: Archive stage artifact
+      uses: actions/upload-artifact@v3
+      with:
+          name: gw2a-18-stage
+          path: GW2A-18*
   pypi:
     runs-on: ubuntu-latest
-    needs: [gw1n1, gw1nz1, gw1n9, gw1n9c, gw1n4, gw1ns2, gw1ns4]
+    needs: [gw1n1, gw1nz1, gw1n9, gw1n9c, gw1n4, gw1ns2, gw1ns4, gw2a18]
     steps:
     - uses: actions/checkout@v3
     - name: Download gw1n-1 chipdb
@@ -176,6 +194,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: gw1ns-4-chipdb
+        path: apycula
+    - name: Download gw2a-18 chipdb
+      uses: actions/download-artifact@v3
+      with:
+        name: gw2a-18-chipdb
         path: apycula
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 .PHONY: all clean
 all: apycula/GW1N-1.pickle apycula/GW1N-9.pickle apycula/GW1N-4.pickle \
 	 apycula/GW1NS-2.pickle apycula/GW1NS-4.pickle apycula/GW1N-9C.pickle \
-	 apycula/GW1NZ-1.pickle
+	 apycula/GW1NZ-1.pickle apycula/GW2A-18.pickle
 
 %.json: apycula/dat19_h4x.py
 	python3 -m apycula.dat19_h4x $*

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -56,6 +56,8 @@ def read_bitstream(fname):
                         padding = 0
                     elif ba == b'\x06\x00\x00\x00\x01\x00\x98\x1b':
                         padding = 0
+                    elif ba == b'\x06\x00\x00\x00\x00\x00\x08\x1b':
+                        padding = 0
                     else:
                         raise ValueError("Unsupported device", ba)
                 preamble = max(0, preamble-1)

--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -337,7 +337,7 @@ def fse_luts(fse, ttyp):
 def fse_osc(device, fse, ttyp):
     osc = {}
 
-    if device in {'GW1N-4', 'GW1N-9', 'GW1N-9C'}:
+    if device in {'GW1N-4', 'GW1N-9', 'GW1N-9C', 'GW2A-18'}:
         bel = osc.setdefault(f"OSC", Bel())
     elif device in {'GW1NZ-1', 'GW1NS-4'}:
         bel = osc.setdefault(f"OSCZ", Bel())
@@ -792,7 +792,7 @@ def add_attr_val(dev, logic_table, attrs, attr, val):
             break
 
 def get_pins(device):
-    if device not in {"GW1N-1", "GW1NZ-1", "GW1N-4", "GW1N-9", "GW1NR-9", "GW1N-9C", "GW1NR-9C", "GW1NS-2", "GW1NS-2C", "GW1NS-4", "GW1NSR-4C"}:
+    if device not in {"GW1N-1", "GW1NZ-1", "GW1N-4", "GW1N-9", "GW1NR-9", "GW1N-9C", "GW1NR-9C", "GW1NS-2", "GW1NS-2C", "GW1NS-4", "GW1NSR-4C", "GW2A-18"}:
         raise Exception(f"unsupported device {device}")
     pkgs = pindef.all_packages(device)
     res = {}
@@ -874,6 +874,11 @@ def json_pinout(device):
             "GW1NS-2": pins,
             "GW1NS-2C": pins_c
         }, res_bank_pins)
+    if device == "GW2A-18":
+        pkgs, pins, bank_pins = get_pins("GW2A-18")
+        return (pkgs, {
+            "GW2A-18": pins
+        }, bank_pins)
     else:
         raise Exception("unsupported device")
 
@@ -919,6 +924,8 @@ _osc_ports = {('OSCZ', 'GW1NZ-1'): ({}, {'OSCOUT' : (0, 5, 'OF3'), 'OSCEN': (0, 
               ('OSC',  'GW1N-4'):  ({'OSCOUT': 'Q4'}, {}),
               ('OSC',  'GW1N-9'):  ({'OSCOUT': 'Q4'}, {}),
               ('OSC',  'GW1N-9C'):  ({'OSCOUT': 'Q4'}, {}),
+              # XXX check this!
+              ('OSC',  'GW2A-18'):  ({'OSCOUT': 'Q4'}, {}),
               # XXX unsupported boards, pure theorizing
               ('OSCO', 'GW1N-2'):  ({'OSCOUT': 'Q7'}, {'OSCEN': (9, 1, 'B4')}),
               ('OSCW', 'GW2AN-18'):  ({'OSCOUT': 'Q4'}, {}),

--- a/apycula/codegen.py
+++ b/apycula/codegen.py
@@ -135,7 +135,7 @@ run pnr
             """
 
         device_desc = self.partnumber
-        if self.device in ['GW1N-9', 'GW1N-4', 'GW1N-9C']:
+        if self.device in ['GW1N-9', 'GW1N-4', 'GW1N-9C', 'GW2A-18']:
             device_desc = f'-name {self.device} {device_desc}'
 
         f.write(template.format(

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -68,6 +68,11 @@ params = {
         "device": "GW1NZ-1-QFN48-6",
         "partnumber": "GW1NZ-LV1QN48C6/I5",
     },
+    "GW2A-18": {
+        "package": "PBGA256",
+        "device": "GW2A-18-PBGA256-8",
+        "partnumber": "GW2A-LV18PG256C8/I7",
+    },
 }[device]
 
 # utils
@@ -275,7 +280,10 @@ if __name__ == "__main__":
         name = pin.upper()
         cfg_attrs = set()
         chipdb.add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids[f'{name}_AS_GPIO'], attrids.cfg_attrvals['YES'])
-        bits = chipdb.get_shortval_fuses(db, fse['header']['grid'][61][0][0], cfg_attrs, 'CFG')
+        if device == 'GW2A-18':
+            bits = chipdb.get_shortval_fuses(db, fse['header']['grid'][61][0][-1], cfg_attrs, 'CFG')
+        else:
+            bits = chipdb.get_shortval_fuses(db, fse['header']['grid'][61][0][0], cfg_attrs, 'CFG')
         tile = db.template
         for row_, col_ in bits:
             tile[row_][col_] = 0

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -6,7 +6,8 @@ NEXTPNR ?= nextpnr-gowin
 include deser/Makefile
 
 all: attosoc-tec0117.fs nanolcd-tangnano.fs blinky-tec0117.fs blinky-runber.fs \
-	blinky-tangnano.fs blinky-honeycomb.fs shift-tec0117.fs shift-runber.fs \
+	blinky-tangnano.fs blinky-honeycomb.fs blinky-primer20k.fs \
+	shift-tec0117.fs shift-runber.fs \
 	shift-tangnano.fs shift-honeycomb.fs \
 	tonegen-tec0117.fs blinky-tangnano9k.fs blinky-tangnano1k.fs blinky-tangnano4k.fs \
 	blinky-tbuf-tangnano.fs blinky-tbuf-tangnano1k.fs blinky-tbuf-tangnano4k.fs \
@@ -64,6 +65,12 @@ clean: clean_deser
 	rm -f *.json *.fs *-unpacked.v
 	
 .PHONY: all unpacked clean
+
+%-primer20k.fs: %-primer20k.json
+	gowin_pack -d GW2A-18 -o $@ $<
+
+%-primer20k.json: %-primer20k-synth.json primer20k.cst
+	$(NEXTPNR) --json $< --write $@ --device GW2A-LV18PG256C8/I7 --cst primer20k.cst
 
 %-tec0117.fs: %-tec0117.json
 	gowin_pack -d GW1N-9 -o $@ $<
@@ -160,6 +167,9 @@ pll2-tec0117-synth.json: pll/GW1N-9-dyn.vh pll2.v pll/rpll.v
 
 pll2-runber-synth.json: pll/GW1N-4-dyn.vh pll2.v pll/rpll.v
 	$(YOSYS) -p "read_verilog $^; synth_gowin -noalu -json $@"
+
+%-primer20k-synth.json: %.v
+	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSC -p "read_verilog $^; synth_gowin -json $@"
 
 %-tec0117-synth.json: %.v
 	$(YOSYS) -D LEDS_NR=8 -D OSC_TYPE_OSC -p "read_verilog $^; synth_gowin -json $@"

--- a/examples/primer20k.cst
+++ b/examples/primer20k.cst
@@ -1,0 +1,8 @@
+IO_LOC "clk" IOT27A;
+IO_LOC "key" IOR35B;
+IO_LOC "led[0]" IOR32B;
+IO_LOC "led[1]" IOR31A;
+IO_LOC "led[2]" IOT52A;
+IO_LOC "led[3]" IOT52B;
+IO_LOC "led[4]" IOT34B;
+IO_LOC "led[5]" IOT34A;


### PR DESCRIPTION
Only the chip GW2A-LV18PG256C8/I7, which is installed in Primer20k.

Support in the volume of workable blinky, no more.