### PR TITLE
Ngi0 reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 *.txt
 *.c
 /*.png

--- a/apycula/__init__.py
+++ b/apycula/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT

--- a/apycula/attrids.py
+++ b/apycula/attrids.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 # These constants are used to interact with the 'logicinfo', 'shortval' and maybe 'longval' tables
 # * - it seems that these attributes must always be present (XXX)
 # Warning:

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 from math import ceil
 import numpy as np
 from crcmod.predefined import mkPredefinedCrcFun

--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple, Union, ByteString
 from itertools import chain

--- a/apycula/clock_fuzzer.py
+++ b/apycula/clock_fuzzer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 from multiprocessing.dummy import Pool
 import pickle
 import json

--- a/apycula/codegen.py
+++ b/apycula/codegen.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 from itertools import chain
 
 class Module:

--- a/apycula/dat19_h4x.py
+++ b/apycula/dat19_h4x.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 import json

--- a/apycula/fuse_h4x.py
+++ b/apycula/fuse_h4x.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 import sys
 import numpy as np
 import random

--- a/apycula/gowin_bba.py
+++ b/apycula/gowin_bba.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 import sys
 import importlib.resources
 import pickle

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 import sys
 import os
 import re

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 import sys
 import os
 import re

--- a/apycula/pindef.py
+++ b/apycula/pindef.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 from os.path import expanduser
 from glob import glob
 import json

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 import re
 import os
 import sys

--- a/apycula/tm_h4x.py
+++ b/apycula/tm_h4x.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 import json

--- a/apycula/wirenames.py
+++ b/apycula/wirenames.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 apicula contributors <https://github.com/YosysHQ/apicula/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
 wirenames = { 0: "A0", 1: "B0", 2: "C0", 3: "D0", 4: "A1", 5: "B1", 6: "C1", 7: "D1", 8: "A2", 9: "B2", 10: "C2", 11: "D2", 12: "A3", 13: "B3", 14: "C3",
 15: "D3", 16: "A4", 17: "B4", 18: "C4", 19: "D4", 20: "A5", 21: "B5", 22: "C5", 23: "D5", 24: "A6", 25: "B6", 26: "C6", 27: "D6", 28: "A7", 29: "B7",
 30: "C7", 31: "D7", 32: "F0", 33: "F1", 34: "F2", 35: "F3", 36: "F4", 37: "F5", 38: "F6", 39: "F7", 40: "Q0", 41: "Q1", 42: "Q2", 43: "Q3", 44: "Q4",

--- a/doc/fig/alu_logic.png.license
+++ b/doc/fig/alu_logic.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/alu_tile.png.license
+++ b/doc/fig/alu_tile.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/clocks.png.license
+++ b/doc/fig/clocks.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/clu.png.license
+++ b/doc/fig/clu.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/floorplanner.png.license
+++ b/doc/fig/floorplanner.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/fuse.png.license
+++ b/doc/fig/fuse.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/lw.png.license
+++ b/doc/fig/lw.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/mux.png.license
+++ b/doc/fig/mux.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/muxes-wiring.png.license
+++ b/doc/fig/muxes-wiring.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/post_pnr.png.license
+++ b/doc/fig/post_pnr.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/post_syn.png.license
+++ b/doc/fig/post_syn.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>

--- a/doc/fig/tile.png.license
+++ b/doc/fig/tile.png.license
@@ -1,0 +1,1 @@
+SPDX-FileCopyrightText: 2023 apicula contributors  <https://github.com/YosysHQ/apicula/graphs/contributors>


### PR DESCRIPTION
Hello,

By way of introduction, I am Jithendra with the Free Software Foundation Europe, a consortium member of the NGI0 Initiative, of which you have signed apicula up for participation and funding. Part of what is offered with your involvement with NGI0 is help from us with your project on your copyright and license management.

After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information in your files. Our REUSE specification (https://reuse.software) intends to make licensing easier with best practices to display legal information through comment headers on source files that can be easily human and machine readable. The REUSE tool makes the process of applying licenses to files and compliance checking much easier.

Instructions on how to install the REUSE tool can be found here: https://reuse.readthedocs.io/en/stable/readme.html#install

You can also check out this screencast for more instructions on how to use the REUSE tool: https://download.fsfe.org/videos/reuse/screencasts/reuse-tool.gif

The changes in this pull request have also been made for you to understand the basic ideas behind REUSE, and how adopting the REUSE practices would look like within your repository.

# REUSE Features:

• SPDX copyright and license comment headers for relevant files.
• LICENSES directory with licenses used in the repository
• Associating copyright/licensing information through a DEP5 file in large directories.
Files Missing Copyright and Licensing Information
I've noticed that several files in your repository already contain information about the copyright and license information for the code in that particular file. That's great! Nevertheless, the idea behind REUSE is that every single file in your repository should have a header that includes this information.

To serve as an example, I added the SPDX headers with copyright and license information to the copyrightable files in a few of the directories (namely all the ".py" files in the /apycula folder). This should give you an idea of how comment headers should look like in a REUSE compliant repository, and how they should be added to the other source code files in your repository.

Please also check if the personal information in these headers are correct and consistent to your knowledge. In the event that there are more copyright holders, please include them in these comment headers.
LICENSES Directory in the Root of the Project Repository

The LICENSES Folder should contain the license text of every license applicable in your repository. I included in this directory the file that contained the MIT and CC0 licenses.

Additionally, I included in this folder the text for the CC0 license. This is because you have files in your project that are not copyrightable, for example configuration files such as .gitignore. As the fundamental idea of REUSE is that all of your files will clearly have their copyright and licensing marked, I have applied the CC0 license to .gitignore, which is functionally identical to putting the file into the public domain.
Image files

# Image files
Additionally, I noticed that you have several image files ".png" in the doc/fig folder. For image files, we recommend creating a .license file, where you can include the comment headers for the license and copyright information. We've added comment headers to all the .png files in doc/fig folder and here listed the project apicula contributors as the copyright holder. Please feel free to modify and update this to your needs.

I hope that you find this useful. Feel free to adopt in case you feel REUSE may help your project with copyright and licensing management. Please feel free to contact me directly at jithendra@fsfe.org if you have any questions.

Best,
Jithendra
(Free Software Foundation Europe)