### PR TITLE
python 3.8 support for importlib files api

### DIFF
--- a/apycula/gowin_bba.py
+++ b/apycula/gowin_bba.py
@@ -4,7 +4,7 @@ import pickle
 import gzip
 import argparse
 import re
-from contextlib import contextmanager
+from contextlib import contextmanager, closing
 from collections import Counter
 from apycula import chipdb
 
@@ -255,8 +255,11 @@ def main():
 
     args = parser.parse_args()
     read_constids(args.constids)
-    with gzip.open(importlib.resources.files("apycula").joinpath(f"{args.device}.pickle"), 'rb') as f:
+
+    with importlib.resources.path('apycula', f'{args.device}.pickle') as path:
+     with closing(gzip.open(path, 'rb')) as f:
         db = pickle.load(f)
+        
     write_chipdb(db, args.output, args.device)
 
 if __name__ == "__main__":

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -10,6 +10,7 @@ import json
 import argparse
 import importlib.resources
 from collections import namedtuple
+from contextlib import closing
 from apycula import codegen
 from apycula import chipdb
 from apycula.chipdb import add_attr_val, get_shortval_fuses, get_longval_fuses, get_bank_fuses
@@ -981,8 +982,12 @@ def main():
         mods = m.group(1) or ""
         luts = m.group(3)
         device = f"GW1N{mods}-{luts}"
-    with gzip.open(importlib.resources.files("apycula").joinpath(f"{device}.pickle"), 'rb') as f:
-        db = pickle.load(f)
+    read_constids(args.constids)
+    
+    with importlib.resources.path('apycula', f'{args.device}.pickle') as path:
+        with closing(gzip.open(path, 'rb')) as f:
+            db = pickle.load(f)
+            
     with open(args.netlist) as f:
         pnr = json.load(f)
 

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -982,7 +982,6 @@ def main():
         mods = m.group(1) or ""
         luts = m.group(3)
         device = f"GW1N{mods}-{luts}"
-    read_constids(args.constids)
     
     with importlib.resources.path('apycula', f'{args.device}.pickle') as path:
         with closing(gzip.open(path, 'rb')) as f:

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -8,6 +8,7 @@ import pickle
 import gzip
 import argparse
 import importlib.resources
+from contextlib import closing
 from apycula import codegen
 from apycula import chipdb
 from apycula import attrids
@@ -1048,6 +1049,7 @@ def main():
         luts = m.group(3)
         _device = f"GW1N{mods}-{luts}"
 
+        
     with gzip.open(importlib.resources.files("apycula").joinpath(f"{_device}.pickle"), 'rb') as f:
         db = pickle.load(f)
 

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -1049,9 +1049,9 @@ def main():
         luts = m.group(3)
         _device = f"GW1N{mods}-{luts}"
 
-        
-    with gzip.open(importlib.resources.files("apycula").joinpath(f"{_device}.pickle"), 'rb') as f:
-        db = pickle.load(f)
+    with importlib.resources.path('apycula', f'{args.device}.pickle') as path:
+        with closing(gzip.open(path, 'rb')) as f:
+            db = pickle.load(f)
 
     global _pinout
     _pinout = db.pinout[_device][_packages[_device]]


### PR DESCRIPTION
to restore python 3.8 support in https://github.com/YosysHQ/oss-cad-suite-build/releases 

untested; hope to download apycula.egg artifact and test using that 