### PR TITLE
Fix OPEN_DRAIN IO attribute

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -519,21 +519,21 @@ _vcc_ios = {'LVCMOS12': '1.2', 'LVCMOS15': '1.5', 'LVCMOS18': '1.8', 'LVCMOS25':
         'LVCMOS33': '3.3', 'LVDS25': '2.5', 'LVCMOS33D': '3.3', 'LVCMOS_D': '3.3'}
 _init_io_attrs = {
         'IBUF': {'PADDI': 'PADDI', 'HYSTERESIS': 'NONE', 'PULLMODE': 'UP', 'SLEWRATE': 'SLOW',
-                 'DRIVE': '0', 'OPENDRAIN': 'OFF', 'CLAMP': 'OFF', 'DIFFRESISTOR': 'OFF',
+                 'DRIVE': '0', 'CLAMP': 'OFF', 'DIFFRESISTOR': 'OFF',
                  'VREF': 'OFF', 'LVDS_OUT': 'OFF'},
-        'OBUF': {'ODMUX_1': '1', 'OPENDRAIN': 'OFF', 'PULLMODE': 'UP', 'SLEWRATE': 'FAST',
+        'OBUF': {'ODMUX_1': '1', 'PULLMODE': 'UP', 'SLEWRATE': 'FAST',
                  'DRIVE': '8', 'HYSTERESIS': 'NONE', 'CLAMP': 'OFF', 'DIFFRESISTOR': 'OFF',
                  'SINGLERESISTOR': 'OFF', 'VCCIO': '1.8', 'LVDS_OUT': 'OFF', 'DDR_DYNTERM': 'NA', 'TO': 'INV'},
-        'TBUF': {'ODMUX_1': 'UNKNOWN', 'OPENDRAIN': 'OFF', 'PULLMODE': 'UP', 'SLEWRATE': 'FAST',
+        'TBUF': {'ODMUX_1': 'UNKNOWN', 'PULLMODE': 'UP', 'SLEWRATE': 'FAST',
                  'DRIVE': '8', 'HYSTERESIS': 'NONE', 'CLAMP': 'OFF', 'DIFFRESISTOR': 'OFF',
                  'SINGLERESISTOR': 'OFF', 'VCCIO': '1.8', 'LVDS_OUT': 'OFF', 'DDR_DYNTERM': 'NA',
                  'TO': 'INV', 'PERSISTENT': 'OFF', 'ODMUX': 'TRIMUX'},
-        'IOBUF': {'ODMUX_1': 'UNKNOWN', 'OPENDRAIN': 'OFF', 'PULLMODE': 'UP', 'SLEWRATE': 'FAST',
+        'IOBUF': {'ODMUX_1': 'UNKNOWN', 'PULLMODE': 'UP', 'SLEWRATE': 'FAST',
                  'DRIVE': '8', 'HYSTERESIS': 'NONE', 'CLAMP': 'OFF', 'DIFFRESISTOR': 'OFF',
                  'SINGLERESISTOR': 'OFF', 'VCCIO': '1.8', 'LVDS_OUT': 'OFF', 'DDR_DYNTERM': 'NA',
                  'TO': 'INV', 'PERSISTENT': 'OFF', 'ODMUX': 'TRIMUX', 'PADDI': 'PADDI'},
         }
-_refine_attrs = {'SLEW_RATE': 'SLEWRATE', 'PULL_MODE': 'PULLMODE'}
+_refine_attrs = {'SLEW_RATE': 'SLEWRATE', 'PULL_MODE': 'PULLMODE', 'OPEN_DRAIN': 'OPENDRAIN'}
 def refine_io_attrs(attr):
     return _refine_attrs.get(attr, attr)
 
@@ -696,6 +696,8 @@ def place(db, tilemap, bels, cst, args):
                     continue
                 if flag_name_val[0] == chipdb.mode_attr_sep + "IO_TYPE":
                     iostd = _iostd_alias.get(flag_name_val[1], flag_name_val[1])
+                else:
+                    io_desc.attrs[flag_name_val[0][1:]] = flag_name_val[1]
             io_desc.attrs['IO_TYPE'] = iostd
             if pinless_io:
                 return
@@ -839,6 +841,8 @@ def place(db, tilemap, bels, cst, args):
                 for k, val in atr.items():
                     if k not in attrids.iob_attrids.keys():
                         print(f'XXX IO: add {k} key handle')
+                    elif k == 'OPENDRAIN' and val == 'OFF':
+                        continue
                     else:
                         add_attr_val(db, 'IOB', iob_attrs, attrids.iob_attrids[k], attrids.iob_attrvals[val])
                         if k in {'VCCIO'}:
@@ -982,11 +986,11 @@ def main():
         mods = m.group(1) or ""
         luts = m.group(3)
         device = f"GW1N{mods}-{luts}"
-    
+
     with importlib.resources.path('apycula', f'{args.device}.pickle') as path:
         with closing(gzip.open(path, 'rb')) as f:
             db = pickle.load(f)
-            
+
     with open(args.netlist) as f:
         pnr = json.load(f)
 


### PR DESCRIPTION
The coding of the OPEN_DRAIN attribute turned out to be not so unambiguous. It looks like there is ON / OFF and one more default state.

As a temporary measure, setting OPEN_DRAIN=OFF is ignored, but you use OPENDRAIN=ON at your own peril and risk.