### PR TITLE
Fix simple examples

### DIFF
--- a/examples/himbaechel/blinky-osc.v
+++ b/examples/himbaechel/blinky-osc.v
@@ -39,6 +39,6 @@ end
 
 // Combinational code (boolean logic)
 assign ctr_d = ctr_q + 1'b1;
-assign led = ctr_q[25:25-(`LEDS_NR - 1)];
+assign led = {ctr_q[25:25-(`LEDS_NR - 2)], |ctr_q[25-(`LEDS_NR - 1):25-(`LEDS_NR)] };
 
 endmodule

--- a/examples/himbaechel/blinky-pll-vr.v
+++ b/examples/himbaechel/blinky-pll-vr.v
@@ -59,6 +59,6 @@ end
 
 // Combinational code (boolean logic)
 assign ctr_d = ctr_q + 1'b1;
-assign led = ctr_q[25:25-(`LEDS_NR - 1)];
+assign led = {ctr_q[25:25-(`LEDS_NR - 2)], |ctr_q[25-(`LEDS_NR - 1):25-(`LEDS_NR)] };
 
 endmodule

--- a/examples/himbaechel/blinky-pll.v
+++ b/examples/himbaechel/blinky-pll.v
@@ -56,6 +56,6 @@ end
 
 // Combinational code (boolean logic)
 assign ctr_d = ctr_q + 1'b1;
-assign led = ctr_q[25:25-(`LEDS_NR - 1)];
+assign led = {ctr_q[25:25-(`LEDS_NR - 2)], |ctr_q[25-(`LEDS_NR - 1):25-(`LEDS_NR)] };
 
 endmodule

--- a/examples/himbaechel/blinky.v
+++ b/examples/himbaechel/blinky.v
@@ -16,6 +16,6 @@ end
 
 // Combinational code (boolean logic)
 assign ctr_d = ctr_q + 1'b1;
-assign led = ctr_q[25:25-(`LEDS_NR - 1)];
+assign led = {ctr_q[25:25-(`LEDS_NR - 2)], |ctr_q[25-(`LEDS_NR - 1):25-(`LEDS_NR)] };
 
 endmodule


### PR DESCRIPTION
Examples consisting of ALUs and DFFs can pack well so there is no need for a LUT. This after causes problems when checking unpacking. Add a simple LUT.