### PR TITLE
BUGFIX: Use parsed device.

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -1381,7 +1381,7 @@ def main():
         mods = m.group(1) or ""
         luts = m.group(3)
         device = f"GW1N{mods}-{luts}"
-    with importlib.resources.path('apycula', f'{args.device}.pickle') as path:
+    with importlib.resources.path('apycula', f'{device}.pickle') as path:
         with closing(gzip.open(path, 'rb')) as f:
             db = pickle.load(f)
 


### PR DESCRIPTION
When switching to Python 3.8, the parsed device was lost.
https://github.com/YosysHQ/apicula/issues/213