### PR TITLE
Fix #219: Python3.8 compatiblity

### DIFF
--- a/.github/workflows/chipdb.yml
+++ b/.github/workflows/chipdb.yml
@@ -233,6 +233,9 @@ jobs:
         pip install setuptools wheel twine
         python setup.py --version
         python setup.py sdist bdist_wheel
+        # Validate that the resulting wheel can be executed
+        pip install dist/Apycula-$(python setup.py --version)-py3-none-any.whl
+        gowin_pack --help
     - name: Archive artifact
       uses: actions/upload-artifact@v3
       with:

--- a/apycula/dat19.py
+++ b/apycula/dat19.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
 import sys
 import os
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Any
 
 
 @dataclass


### PR DESCRIPTION
My changes to the DAT file parser do not run on Python3.8 and the validation tests passed, as they run on Python3.9.

If bumping the requirement to 3.9 is not reasonable, this PR adds a sanity check by executing `gowin_pack` on 3.8.
I added the check to the `pypi` job to prevent the publish step from being runnable, but I could also move this into a new job that runs on 3.8