### PR TITLE
Properly handle external 9C clock pins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ apycula/%.pickle: %_stage2.pickle
 	gzip -c $< > $@
 
 clean:
-	rm *.json
-	rm *.pickle
-	rm apycula/*.pickle
+	rm -f *.json
+	rm -f *.pickle
+	rm -f apycula/*.pickle


### PR DESCRIPTION
The GW1NR-9C has interesting clock pins on the bottom side - they do not connect directly to the central MUX, but pass through an additional MUX in the corner cell. Let's take this into account.

