### PR TITLE
Add support for four IOLOGICs in one cell

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -868,8 +868,10 @@ def place(db, tilemap, bels, cst, args):
                 parms['ENABLE_USED'] = "0"
             typ = 'IOB'
 
-        if is_himbaechel and typ in {'IOLOGIC', 'IOLOGIC_DUMMY', 'ODDR', 'ODDRC', 'OSER4', 'OSER8', 'OSER10', 'OVIDEO',
-                   'IDDR', 'IDDRC', 'IDES4', 'IDES8', 'IDES10', 'IVIDEO'}:
+        if is_himbaechel and typ in {'IOLOGIC', 'IOLOGICI', 'IOLOGICO', 'IOLOGIC_DUMMY', 'ODDR', 'ODDRC', 'OSER4',
+                                     'OSER8', 'OSER10', 'OVIDEO', 'IDDR', 'IDDRC', 'IDES4', 'IDES8', 'IDES10', 'IVIDEO'}:
+            if num[-1] in {'I', 'O'}:
+                num = num[:-1]
             if typ == 'IOLOGIC_DUMMY':
                 attrs['IOLOGIC_FCLK'] = pnr['modules']['top']['cells'][attrs['MAIN_CELL']]['attributes']['IOLOGIC_FCLK']
             attrs['IOLOGIC_TYPE'] = typ
@@ -1030,7 +1032,7 @@ def place(db, tilemap, bels, cst, args):
                 typ = cell['type']
             bsram_attrs = set_bsram_attrs(db, typ, parms)
             bsrambits = get_shortval_fuses(db, tiledata.ttyp, bsram_attrs, f'BSRAM_{typ}')
-            print(f'({row - 1}, {col - 1}) attrs:{bsram_attrs}, bits:{bsrambits}')
+            #print(f'({row - 1}, {col - 1}) attrs:{bsram_attrs}, bits:{bsrambits}')
             for brow, bcol in bsrambits:
                 tile[brow][bcol] = 1
         elif typ.startswith('RPLL'):


### PR DESCRIPTION
There's actually very little going on on the apicula side, but a future nextpnr fix will split each of IOLOGICA and IOLOGICB into two directions: IOLOGIC in and IOLOGIC out. This allows us to combine two IOLOGICs at once to work with IOBUF, which addresses issue https://github.com/YosysHQ/nextpnr/issues/1275

The nature of the fixes in this PR is such that it will work with the old version of nextpnr and everything that successfully passes through netxpnr will work.