### PR TITLE
Examples. Describe the Tangnano4k clock pin.

### DIFF
--- a/examples/himbaechel/tangnano4k.cst
+++ b/examples/himbaechel/tangnano4k.cst
@@ -7,7 +7,10 @@ IO_LOC "led[4]" 31;
 IO_LOC "led[5]" 32;
 IO_LOC "key_i" 15;
 IO_LOC "rst_i" 14;
+
 IO_LOC "clk" 45;
+CLOCK_LOC "clk" BUFG;
+
 
 IO_PORT "key_i" PULLMODE=UP;
 IO_PORT "rst_i" PULLMODE=UP;

--- a/examples/himbaechel/tangnano4k.cst
+++ b/examples/himbaechel/tangnano4k.cst
@@ -12,8 +12,8 @@ IO_LOC "clk" 45;
 CLOCK_LOC "clk" BUFG;
 
 
-IO_PORT "key_i" PULLMODE=UP;
-IO_PORT "rst_i" PULLMODE=UP;
+IO_PORT "key_i" PULL_MODE=UP;
+IO_PORT "rst_i" PULL_MODE=UP;
 
 // oser
 IO_LOC "oser_out" 35;


### PR DESCRIPTION
The point is that the external crystal on this board is soldered to a pin, which is a PLL input, not a clock pin. Therefore, common routing is used.

By specifying that this is a buffered network, we are forcing the router to use global clock wires.