### PR TITLE
Add examples with tiny RISCV

### DIFF
--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -102,7 +102,7 @@ def tbrl2rc(fse, side, num):
 
 # Read the packer vendor log to identify problem with primitives/attributes
 # returns dictionary {(primitive name, error code) : [full error text]}
-_err_parser = re.compile("(\w+) +\(([\w\d]+)\).*'(inst[^\']+)\'.*")
+_err_parser = re.compile(r"(\w+) +\(([\w\d]+)\).*'(inst[^\']+)\'.*")
 def read_err_log(fname):
     errs = {}
     with open(fname, 'r') as f:

--- a/examples/himbaechel/Makefile.himbaechel
+++ b/examples/himbaechel/Makefile.himbaechel
@@ -12,6 +12,7 @@ all: \
 	bsram-pROM-tangnano20k.fs bsram-SDPB-tangnano20k.fs bsram-SP-tangnano20k.fs \
 	bsram-DPB-tangnano20k.fs bsram-pROMX9-tangnano20k.fs bsram-SDPX9B-tangnano20k.fs \
 	bsram-SPX9-tangnano20k.fs bsram-DPX9B-tangnano20k.fs \
+	femto-riscv-15-tangnano20k.fs femto-riscv-16-tangnano20k.fs femto-riscv-16-tangnano20k.fs \
 	\
 	blinky-primer20k.fs shift-primer20k.fs blinky-tbuf-primer20k.fs blinky-oddr-primer20k.fs \
 	blinky-osc-primer20k.fs tlvds-primer20k.fs elvds-primer20k.fs oddr-tlvds-primer20k.fs \
@@ -45,6 +46,7 @@ all: \
 	ides16-tangnano4k.fs \
 	ides4-tangnano4k.fs ivideo-tangnano4k.fs ides8-tangnano4k.fs ides10-tangnano4k.fs \
 	oser10-tlvds-tangnano4k.fs \
+	femto-riscv-15-tangnano4k.fs femto-riscv-16-tangnano4k.fs femto-riscv-16-tangnano4k.fs \
 	\
 	blinky-tangnano9k.fs shift-tangnano9k.fs blinky-tbuf-tangnano9k.fs blinky-oddr-tangnano9k.fs \
 	blinky-osc-tangnano9k.fs tlvds-tangnano9k.fs elvds-tangnano9k.fs oddr-tlvds-tangnano9k.fs \
@@ -55,6 +57,7 @@ all: \
 	bsram-DPB-tangnano9k.fs bsram-pROMX9-tangnano9k.fs bsram-SDPX9B-tangnano9k.fs \
 	bsram-SPX9-tangnano9k.fs bsram-DPX9B-tangnano9k.fs \
 	oser10-elvds-tangnano9k.fs \
+	femto-riscv-15-tangnano9k.fs femto-riscv-16-tangnano9k.fs femto-riscv-18-tangnano9k.fs \
 	\
 	blinky-szfpga.fs shift-szfpga.fs blinky-tbuf-szfpga.fs blinky-oddr-szfpga.fs \
 	blinky-osc-szfpga.fs tlvds-szfpga.fs elvds-szfpga.fs oddr-tlvds-szfpga.fs \
@@ -185,7 +188,7 @@ clean:
 	$(NEXTPNR) --json $< --write $@ --device GW2AR-LV18QN88C8/I7 --vopt family=GW2A-18C --vopt cst=tangnano20k.cst
 
 %-tangnano20k-synth.json: %.v
-	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSC -D INV_BTN=1 -p "read_verilog $^; synth_gowin -json $@"
+	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSC -D INV_BTN=1 -D CPU_FREQ=27 -D BAUD_RATE=115200 -p "read_verilog $^; synth_gowin -json $@"
 
 pll-nanolcd-tangnano20k-synth.json: pll/GW2A-18-dyn.vh pll-nanolcd/TOP.v pll-nanolcd/VGAMod.v
 	$(YOSYS) -D INV_BTN=1 -p "read_verilog $^; synth_gowin -json $@"
@@ -262,7 +265,7 @@ bsram-%-tangnano1k-synth.json: pll/GW1NZ-1-dyn.vh %-image-rom.v %-video-ram.v %.
 	$(NEXTPNR) --json $< --write $@ --device GW1NSR-LV4CQN48PC7/I6 --vopt cst=tangnano4k.cst
 
 %-tangnano4k-synth.json: %.v
-	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSCZ -D INV_BTN=0 -p "read_verilog $^; synth_gowin -json $@"
+	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSCZ -D INV_BTN=0 -D FORCE_BRAM -D CPU_FREQ=27 -D BAUD_RATE=115200 -p "read_verilog $^; synth_gowin -json $@"
 
 blinky-pll-tangnano4k-synth.json: pll/GW1NS-4-dyn.vh blinky-pll-vr.v
 	$(YOSYS) -D INV_BTN=0 -D LEDS_NR=6 -p "read_verilog $^; synth_gowin -json $@"
@@ -276,7 +279,7 @@ blinky-pll-tangnano4k-synth.json: pll/GW1NS-4-dyn.vh blinky-pll-vr.v
 	$(NEXTPNR) --json $< --write $@ --device GW1NR-LV9QN88PC6/I5 --vopt family=GW1N-9C --vopt cst=tangnano9k.cst
 
 %-tangnano9k-synth.json: %.v
-	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSC -D INV_BTN=0 -p "read_verilog $^; synth_gowin -json $@"
+	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSC -D INV_BTN=0 -D CPU_FREQ=27 -D BAUD_RATE=115200 -p "read_verilog $^; synth_gowin -json $@"
 
 pll-nanolcd-tangnano9k-synth.json: pll/GW1N-9C-dyn.vh pll-nanolcd/TOP.v pll-nanolcd/VGAMod.v
 	$(YOSYS) -D INV_BTN=0 -p "read_verilog $^; synth_gowin -json $@"

--- a/examples/himbaechel/clockworks.v
+++ b/examples/himbaechel/clockworks.v
@@ -1,0 +1,55 @@
+ /*
+ * Copyright (c) 2020, Bruno Levy
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+`default_nettype none
+
+module Clockworks (
+	input  wire CLK,
+	input  wire RESET,
+	output wire clk,
+	output wire resetn
+);
+	parameter SLOW = 0;
+
+	assign resetn = RESET ^ `INV_BTN;
+	generate
+		if (SLOW != 0) begin
+			localparam slow_bits = SLOW;
+
+			reg [SLOW:0] slow_CLK = 0;
+			always @(posedge CLK) begin
+				slow_CLK <= slow_CLK + 1;
+			end
+			assign clk = slow_CLK[slow_bits];
+		end else begin
+			assign clk = CLK;
+		end
+	endgenerate
+endmodule
+

--- a/examples/himbaechel/emitter_uart.v
+++ b/examples/himbaechel/emitter_uart.v
@@ -1,0 +1,72 @@
+ /*
+ * Copyright (c) 2020, Bruno Levy
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+module corescore_emitter_uart
+  #(
+    parameter clk_freq_hz = 0,
+    parameter baud_rate = 57600)
+  (
+   input wire 	    i_clk,
+   input wire 	    i_rst,
+   input wire [7:0] i_data,
+   input wire 	    i_valid,
+   output reg 	    o_ready,
+   output wire 	    o_uart_tx
+);
+
+   localparam START_VALUE = clk_freq_hz/baud_rate;
+   
+   localparam WIDTH = $clog2(START_VALUE);
+   
+   reg [WIDTH:0]  cnt = 0;
+   
+   reg [9:0] 	    data;
+
+   assign o_uart_tx = data[0] | !(|data);
+
+   always @(posedge i_clk) begin
+      if (cnt[WIDTH] & !(|data)) begin
+	 o_ready <= 1'b1;
+      end else if (i_valid & o_ready) begin
+	 o_ready <= 1'b0;
+      end
+
+      if (o_ready | cnt[WIDTH])
+	cnt <= {1'b0,START_VALUE[WIDTH-1:0]};
+      else
+	cnt <= cnt-1;
+      
+      if (cnt[WIDTH])
+	data <= {1'b0, data[9:1]};
+      else if (i_valid & o_ready)
+	data <= {1'b1, i_data, 1'b0};
+   end
+
+endmodule
+

--- a/examples/himbaechel/femto-riscv-15.v
+++ b/examples/himbaechel/femto-riscv-15.v
@@ -1,0 +1,371 @@
+/**
+ *  
+ * Step 15: Creating a RISC-V processor
+ *         Load
+ * 
+ * Copyright (c) 2020, Bruno Levy
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+`default_nettype none
+`include "clockworks.v"
+
+module Memory (
+   input             clk,
+   input      [31:0] mem_addr,  // address to be read
+   output reg [31:0] mem_rdata, // data read from memory
+   input   	     mem_rstrb  // goes high when processor wants to read
+);
+
+   reg [31:0] MEM [0:255]; 
+
+   localparam slow_bit=19;
+   
+`include "riscv_assembly.v"
+   integer L0_   = 8;
+   integer wait_ = 32;
+   integer L1_   = 40;
+   
+   initial begin
+      LI(s0,0);   
+      LI(s1,16);
+   Label(L0_); 
+      LB(a0,s0,400); // LEDs are plugged on a0 (=x10)
+      CALL(LabelRef(wait_));
+      ADDI(s0,s0,1); 
+      BNE(s0,s1, LabelRef(L0_));
+      EBREAK();
+      
+   Label(wait_);
+      LI(t0,1);
+      SLLI(t0,t0,slow_bit);
+   Label(L1_);
+      ADDI(t0,t0,-1);
+      BNEZ(t0,LabelRef(L1_));
+      RET();
+
+      endASM();
+
+      // Note: index 100 (word address)
+      //     corresponds to 
+      // address 400 (byte address)
+      MEM[100] = {8'h4, 8'h3, 8'h2, 8'h1};
+      MEM[101] = {8'h8, 8'h7, 8'h6, 8'h5};
+      MEM[102] = {8'hc, 8'hb, 8'ha, 8'h9};
+      MEM[103] = {8'hff, 8'hf, 8'he, 8'hd};            
+   end
+
+   always @(posedge clk) begin
+      if(mem_rstrb) begin
+         mem_rdata <= MEM[mem_addr[31:2]];
+      end
+   end
+endmodule
+
+
+module Processor (
+    input 	      clk,
+    input 	      resetn,
+    output     [31:0] mem_addr, 
+    input      [31:0] mem_rdata, 
+    output 	      mem_rstrb,
+    output reg [31:0] x10 = 0		  
+);
+
+   reg [31:0] PC=0;        // program counter
+   reg [31:0] instr;       // current instruction
+
+   // See the table P. 105 in RISC-V manual
+   
+   // The 10 RISC-V instructions
+   wire isALUreg  =  (instr[6:0] == 7'b0110011); // rd <- rs1 OP rs2   
+   wire isALUimm  =  (instr[6:0] == 7'b0010011); // rd <- rs1 OP Iimm
+   wire isBranch  =  (instr[6:0] == 7'b1100011); // if(rs1 OP rs2) PC<-PC+Bimm
+   wire isJALR    =  (instr[6:0] == 7'b1100111); // rd <- PC+4; PC<-rs1+Iimm
+   wire isJAL     =  (instr[6:0] == 7'b1101111); // rd <- PC+4; PC<-PC+Jimm
+   wire isAUIPC   =  (instr[6:0] == 7'b0010111); // rd <- PC + Uimm
+   wire isLUI     =  (instr[6:0] == 7'b0110111); // rd <- Uimm   
+   wire isLoad    =  (instr[6:0] == 7'b0000011); // rd <- mem[rs1+Iimm]
+   wire isStore   =  (instr[6:0] == 7'b0100011); // mem[rs1+Simm] <- rs2
+   wire isSYSTEM  =  (instr[6:0] == 7'b1110011); // special
+
+   // The 5 immediate formats
+   wire [31:0] Uimm={    instr[31],   instr[30:12], {12{1'b0}}};
+   wire [31:0] Iimm={{21{instr[31]}}, instr[30:20]};
+   wire [31:0] Simm={{21{instr[31]}}, instr[30:25],instr[11:7]};
+   wire [31:0] Bimm={{20{instr[31]}}, instr[7],instr[30:25],instr[11:8],1'b0};
+   wire [31:0] Jimm={{12{instr[31]}}, instr[19:12],instr[20],instr[30:21],1'b0};
+
+   // Source and destination registers
+   wire [4:0] rs1Id = instr[19:15];
+   wire [4:0] rs2Id = instr[24:20];
+   wire [4:0] rdId  = instr[11:7];
+   
+   // function codes
+   wire [2:0] funct3 = instr[14:12];
+   wire [6:0] funct7 = instr[31:25];
+   
+   // The registers bank
+`ifdef FORCE_BRAM
+   (* ram_style = "block" *)
+`endif
+   reg [31:0] RegisterBank [0:31];
+   reg [31:0] rs1; // value of source
+   reg [31:0] rs2; //  registers.
+   wire [31:0] writeBackData; // data to be written to rd
+   wire        writeBackEn;   // asserted if data should be written to rd
+
+   // The ALU
+   wire [31:0] aluIn1 = rs1;
+   wire [31:0] aluIn2 = isALUreg | isBranch ? rs2 : Iimm;
+
+   wire [4:0] shamt = isALUreg ? rs2[4:0] : instr[24:20]; // shift amount
+
+   // The adder is used by both arithmetic instructions and JALR.
+   wire [31:0] aluPlus = aluIn1 + aluIn2;
+
+   // Use a single 33 bits subtract to do subtraction and all comparisons
+   // (trick borrowed from swapforth/J1)
+   wire [32:0] aluMinus = {1'b1, ~aluIn2} + {1'b0,aluIn1} + 33'b1;
+   wire        LT  = (aluIn1[31] ^ aluIn2[31]) ? aluIn1[31] : aluMinus[32];
+   wire        LTU = aluMinus[32];
+   wire        EQ  = (aluMinus[31:0] == 0);
+
+   // Flip a 32 bit word. Used by the shifter (a single shifter for
+   // left and right shifts, saves silicium !)
+   function [31:0] flip32;
+      input [31:0] x;
+      flip32 = {x[ 0], x[ 1], x[ 2], x[ 3], x[ 4], x[ 5], x[ 6], x[ 7], 
+		x[ 8], x[ 9], x[10], x[11], x[12], x[13], x[14], x[15], 
+		x[16], x[17], x[18], x[19], x[20], x[21], x[22], x[23],
+		x[24], x[25], x[26], x[27], x[28], x[29], x[30], x[31]};
+   endfunction
+
+   wire [31:0] shifter_in = (funct3 == 3'b001) ? flip32(aluIn1) : aluIn1;
+   
+   /* verilator lint_off WIDTH */
+   wire [31:0] shifter = 
+               $signed({instr[30] & aluIn1[31], shifter_in}) >>> aluIn2[4:0];
+   /* verilator lint_on WIDTH */
+
+   wire [31:0] leftshift = flip32(shifter);
+   
+
+   
+   // ADD/SUB/ADDI: 
+   // funct7[5] is 1 for SUB and 0 for ADD. We need also to test instr[5]
+   // to make the difference with ADDI
+   //
+   // SRLI/SRAI/SRL/SRA: 
+   // funct7[5] is 1 for arithmetic shift (SRA/SRAI) and 
+   // 0 for logical shift (SRL/SRLI)
+   reg [31:0]  aluOut;
+   always @(*) begin
+      case(funct3)
+	3'b000: aluOut = (funct7[5] & instr[5]) ? aluMinus[31:0] : aluPlus;
+	3'b001: aluOut = leftshift;
+	3'b010: aluOut = {31'b0, LT};
+	3'b011: aluOut = {31'b0, LTU};
+	3'b100: aluOut = (aluIn1 ^ aluIn2);
+	3'b101: aluOut = shifter;
+	3'b110: aluOut = (aluIn1 | aluIn2);
+	3'b111: aluOut = (aluIn1 & aluIn2);	
+      endcase
+   end
+
+   // The predicate for branch instructions
+   reg takeBranch;
+   always @(*) begin
+      case(funct3)
+	3'b000: takeBranch = EQ;
+	3'b001: takeBranch = !EQ;
+	3'b100: takeBranch = LT;
+	3'b101: takeBranch = !LT;
+	3'b110: takeBranch = LTU;
+	3'b111: takeBranch = !LTU;
+	default: takeBranch = 1'b0;
+      endcase
+   end
+   
+
+   // Address computation
+   // An adder used to compute branch address, JAL address and AUIPC.
+   // branch->PC+Bimm    AUIPC->PC+Uimm    JAL->PC+Jimm
+   // Equivalent to PCplusImm = PC + (isJAL ? Jimm : isAUIPC ? Uimm : Bimm)
+   wire [31:0] PCplusImm = PC + ( instr[3] ? Jimm[31:0] :
+				  instr[4] ? Uimm[31:0] :
+				             Bimm[31:0] );
+   wire [31:0] PCplus4 = PC+4;
+   
+   // register write back
+   assign writeBackData = (isJAL || isJALR) ? PCplus4   :
+			      isLUI         ? Uimm      :
+			      isAUIPC       ? PCplusImm :
+			      isLoad        ? LOAD_data :
+			                      aluOut;
+
+   assign writeBackEn = (state==EXECUTE && !isBranch && !isStore && !isLoad) ||
+			(state==WAIT_DATA) ;
+   
+   wire [31:0] nextPC = ((isBranch && takeBranch) || isJAL) ? PCplusImm   :
+	                                  isJALR   ? {aluPlus[31:1],1'b0} :
+	                                             PCplus4;
+
+   wire [31:0] loadstore_addr = rs1 + Iimm;
+   
+   // Load
+   // All memory accesses are aligned on 32 bits boundary. For this
+   // reason, we need some circuitry that does unaligned halfword
+   // and byte load/store, based on:
+   // - funct3[1:0]:  00->byte 01->halfword 10->word
+   // - mem_addr[1:0]: indicates which byte/halfword is accessed
+
+   wire mem_byteAccess     = funct3[1:0] == 2'b00;
+   wire mem_halfwordAccess = funct3[1:0] == 2'b01;
+
+
+   wire [15:0] LOAD_halfword =
+	       loadstore_addr[1] ? mem_rdata[31:16] : mem_rdata[15:0];
+
+   wire  [7:0] LOAD_byte =
+	       loadstore_addr[0] ? LOAD_halfword[15:8] : LOAD_halfword[7:0];
+
+   // LOAD, in addition to funct3[1:0], LOAD depends on:
+   // - funct3[2] (instr[14]): 0->do sign expansion   1->no sign expansion
+   wire LOAD_sign =
+	!funct3[2] & (mem_byteAccess ? LOAD_byte[7] : LOAD_halfword[15]);
+
+   wire [31:0] LOAD_data =
+         mem_byteAccess ? {{24{LOAD_sign}},     LOAD_byte} :
+     mem_halfwordAccess ? {{16{LOAD_sign}}, LOAD_halfword} :
+                          mem_rdata ;
+
+   
+   // The state machine
+   localparam FETCH_INSTR = 0;
+   localparam WAIT_INSTR  = 1;
+   localparam FETCH_REGS  = 2;
+   localparam EXECUTE     = 3;
+   localparam LOAD        = 4;
+   localparam WAIT_DATA   = 5;
+   reg [2:0] state = FETCH_INSTR;
+   
+   always @(posedge clk) begin
+      if(!resetn) begin
+	 PC    <= 0;
+	 state <= FETCH_INSTR;
+      end else begin
+	 if(writeBackEn && rdId != 0) begin
+	    RegisterBank[rdId] <= writeBackData;
+		if(rdId == 10) begin
+           x10 <= writeBackData;
+        end
+	 end
+	 case(state)
+	   FETCH_INSTR: begin
+	      state <= WAIT_INSTR;
+	   end
+	   WAIT_INSTR: begin
+	      instr <= mem_rdata;
+	      state <= FETCH_REGS;
+	   end
+	   FETCH_REGS: begin
+	      rs1 <= RegisterBank[rs1Id];
+	      rs2 <= RegisterBank[rs2Id];
+	      state <= EXECUTE;
+	   end
+	   EXECUTE: begin
+	      if(!isSYSTEM) begin
+		 PC <= nextPC;
+	      end
+	      state <= isLoad ? LOAD : FETCH_INSTR;
+	   end
+	   LOAD: begin
+	      state <= WAIT_DATA;
+	   end
+	   WAIT_DATA: begin
+	      state <= FETCH_INSTR;
+	   end
+	 endcase 
+      end
+   end
+
+   assign mem_addr = (state == WAIT_INSTR || state == FETCH_INSTR) ?
+		     PC : loadstore_addr ;
+   assign mem_rstrb = (state == FETCH_INSTR || state == LOAD);
+   
+endmodule
+
+
+module top (
+    input  clk_i,      // system clock 
+    input  rst_i,      // reset button
+    output [5:0] led,  // system LEDs
+    input  RXD,        // UART receive
+    output TXD         // UART transmit
+);
+
+   wire clk;
+   wire resetn;
+
+   Memory RAM(
+      .clk(clk),
+      .mem_addr(mem_addr),
+      .mem_rdata(mem_rdata),
+      .mem_rstrb(mem_rstrb)
+   );
+
+   wire [31:0] mem_addr;
+   wire [31:0] mem_rdata;
+   wire mem_rstrb;
+   wire [31:0] x10;
+
+   Processor CPU(
+      .clk(clk),
+      .resetn(resetn),		 
+      .mem_addr(mem_addr),
+      .mem_rdata(mem_rdata),
+      .mem_rstrb(mem_rstrb),
+      .x10(x10)		 
+   );
+   assign led = ~x10[5:0];
+
+   // Gearbox and reset circuitry.
+   Clockworks #(
+	 .SLOW(0)    //Specifying a value other than zero here may result in
+				 // nextpnr being unable to route the clock for some boards. BUGFIX is under development. 
+   ) CW (
+     .CLK(clk_i),
+     .RESET(rst_i),
+     .clk(clk),
+     .resetn(resetn)
+   );
+   
+   assign TXD  = 1'b0; // not used for now         
+endmodule
+

--- a/examples/himbaechel/femto-riscv-16.v
+++ b/examples/himbaechel/femto-riscv-16.v
@@ -1,0 +1,441 @@
+/**
+ * Step 16: Creating a RISC-V processor
+ *         Store
+ *
+ * Copyright (c) 2020, Bruno Levy
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+`default_nettype none
+`include "clockworks.v"
+
+module Memory (
+   input             clk,
+   input      [31:0] mem_addr,  // address to be read
+   output reg [31:0] mem_rdata, // data read from memory
+   input   	     mem_rstrb, // goes high when processor wants to read
+   input      [31:0] mem_wdata, // data to be written
+   input      [3:0]  mem_wmask	// masks for writing the 4 bytes (1=write byte) 
+);
+
+   reg [31:0] MEM [0:255]; 
+
+   localparam slow_bit=17;
+   
+`include "riscv_assembly.v"
+   integer L0_   = 12;
+   integer L1_   = 40;
+   integer wait_ = 64;   
+   integer L2_   = 72;
+   
+   initial begin
+
+      LI(a0,0);
+   // Copy 16 bytes from adress 400
+   // to address 800
+      LI(s1,16);      
+      LI(s0,0);         
+   Label(L0_); 
+      LB(a1,s0,400);
+      SB(a1,s0,800);       
+      CALL(LabelRef(wait_));
+      ADDI(s0,s0,1); 
+      BNE(s0,s1, LabelRef(L0_));
+
+   // Read 16 bytes from adress 800
+      LI(s0,0);
+   Label(L1_);
+      LB(a0,s0,800); // a0 (=x10) is plugged to the LEDs
+      CALL(LabelRef(wait_));
+      ADDI(s0,s0,1); 
+      BNE(s0,s1, LabelRef(L1_));
+      EBREAK();
+      
+   Label(wait_);
+      LI(t0,1);
+      SLLI(t0,t0,slow_bit);
+   Label(L2_);
+      ADDI(t0,t0,-1);
+      BNEZ(t0,LabelRef(L2_));
+      RET();
+
+      endASM();
+
+      // Note: index 100 (word address)
+      //     corresponds to 
+      // address 400 (byte address)
+      MEM[100] = {8'h4, 8'h3, 8'h2, 8'h1};
+      MEM[101] = {8'h8, 8'h7, 8'h6, 8'h5};
+      MEM[102] = {8'hc, 8'hb, 8'ha, 8'h9};
+      MEM[103] = {8'hff, 8'hf, 8'he, 8'hd};            
+   end
+
+   wire [29:0] word_addr = mem_addr[31:2];
+   
+   always @(posedge clk) begin
+      if(mem_rstrb) begin
+         mem_rdata <= MEM[word_addr];
+      end
+      if(mem_wmask[0]) MEM[word_addr][ 7:0 ] <= mem_wdata[ 7:0 ];
+      if(mem_wmask[1]) MEM[word_addr][15:8 ] <= mem_wdata[15:8 ];
+      if(mem_wmask[2]) MEM[word_addr][23:16] <= mem_wdata[23:16];
+      if(mem_wmask[3]) MEM[word_addr][31:24] <= mem_wdata[31:24];	 
+   end
+endmodule
+
+
+module Processor (
+    input 	      clk,
+    input 	      resetn,
+    output [31:0]     mem_addr, 
+    input [31:0]      mem_rdata, 
+    output 	      mem_rstrb,
+    output [31:0]     mem_wdata,
+    output [3:0]      mem_wmask,
+    output reg [31:0] x10 = 0		  
+);
+
+   reg [31:0] PC=0;        // program counter
+   reg [31:0] instr;       // current instruction
+
+   // See the table P. 105 in RISC-V manual
+   
+   // The 10 RISC-V instructions
+   wire isALUreg  =  (instr[6:0] == 7'b0110011); // rd <- rs1 OP rs2   
+   wire isALUimm  =  (instr[6:0] == 7'b0010011); // rd <- rs1 OP Iimm
+   wire isBranch  =  (instr[6:0] == 7'b1100011); // if(rs1 OP rs2) PC<-PC+Bimm
+   wire isJALR    =  (instr[6:0] == 7'b1100111); // rd <- PC+4; PC<-rs1+Iimm
+   wire isJAL     =  (instr[6:0] == 7'b1101111); // rd <- PC+4; PC<-PC+Jimm
+   wire isAUIPC   =  (instr[6:0] == 7'b0010111); // rd <- PC + Uimm
+   wire isLUI     =  (instr[6:0] == 7'b0110111); // rd <- Uimm   
+   wire isLoad    =  (instr[6:0] == 7'b0000011); // rd <- mem[rs1+Iimm]
+   wire isStore   =  (instr[6:0] == 7'b0100011); // mem[rs1+Simm] <- rs2
+   wire isSYSTEM  =  (instr[6:0] == 7'b1110011); // special
+
+   // The 5 immediate formats
+   wire [31:0] Uimm={    instr[31],   instr[30:12], {12{1'b0}}};
+   wire [31:0] Iimm={{21{instr[31]}}, instr[30:20]};
+   wire [31:0] Simm={{21{instr[31]}}, instr[30:25],instr[11:7]};
+   wire [31:0] Bimm={{20{instr[31]}}, instr[7],instr[30:25],instr[11:8],1'b0};
+   wire [31:0] Jimm={{12{instr[31]}}, instr[19:12],instr[20],instr[30:21],1'b0};
+
+   // Source and destination registers
+   wire [4:0] rs1Id = instr[19:15];
+   wire [4:0] rs2Id = instr[24:20];
+   wire [4:0] rdId  = instr[11:7];
+   
+   // function codes
+   wire [2:0] funct3 = instr[14:12];
+   wire [6:0] funct7 = instr[31:25];
+   
+   // The registers bank
+`ifdef FORCE_BRAM
+   (* ram_style = "block" *)
+`endif
+   reg [31:0] RegisterBank [0:31];
+   reg [31:0] rs1; // value of source
+   reg [31:0] rs2; //  registers.
+   wire [31:0] writeBackData; // data to be written to rd
+   wire        writeBackEn;   // asserted if data should be written to rd
+
+   // The ALU
+   wire [31:0] aluIn1 = rs1;
+   wire [31:0] aluIn2 = isALUreg | isBranch ? rs2 : Iimm;
+
+   wire [4:0] shamt = isALUreg ? rs2[4:0] : instr[24:20]; // shift amount
+
+   // The adder is used by both arithmetic instructions and JALR.
+   wire [31:0] aluPlus = aluIn1 + aluIn2;
+
+   // Use a single 33 bits subtract to do subtraction and all comparisons
+   // (trick borrowed from swapforth/J1)
+   wire [32:0] aluMinus = {1'b1, ~aluIn2} + {1'b0,aluIn1} + 33'b1;
+   wire        LT  = (aluIn1[31] ^ aluIn2[31]) ? aluIn1[31] : aluMinus[32];
+   wire        LTU = aluMinus[32];
+   wire        EQ  = (aluMinus[31:0] == 0);
+
+   // Flip a 32 bit word. Used by the shifter (a single shifter for
+   // left and right shifts, saves silicium !)
+   function [31:0] flip32;
+      input [31:0] x;
+      flip32 = {x[ 0], x[ 1], x[ 2], x[ 3], x[ 4], x[ 5], x[ 6], x[ 7], 
+		x[ 8], x[ 9], x[10], x[11], x[12], x[13], x[14], x[15], 
+		x[16], x[17], x[18], x[19], x[20], x[21], x[22], x[23],
+		x[24], x[25], x[26], x[27], x[28], x[29], x[30], x[31]};
+   endfunction
+
+   wire [31:0] shifter_in = (funct3 == 3'b001) ? flip32(aluIn1) : aluIn1;
+   
+   /* verilator lint_off WIDTH */
+   wire [31:0] shifter = 
+               $signed({instr[30] & aluIn1[31], shifter_in}) >>> aluIn2[4:0];
+   /* verilator lint_on WIDTH */
+
+   wire [31:0] leftshift = flip32(shifter);
+   
+
+   
+   // ADD/SUB/ADDI: 
+   // funct7[5] is 1 for SUB and 0 for ADD. We need also to test instr[5]
+   // to make the difference with ADDI
+   //
+   // SRLI/SRAI/SRL/SRA: 
+   // funct7[5] is 1 for arithmetic shift (SRA/SRAI) and 
+   // 0 for logical shift (SRL/SRLI)
+   reg [31:0]  aluOut;
+   always @(*) begin
+      case(funct3)
+	3'b000: aluOut = (funct7[5] & instr[5]) ? aluMinus[31:0] : aluPlus;
+	3'b001: aluOut = leftshift;
+	3'b010: aluOut = {31'b0, LT};
+	3'b011: aluOut = {31'b0, LTU};
+	3'b100: aluOut = (aluIn1 ^ aluIn2);
+	3'b101: aluOut = shifter;
+	3'b110: aluOut = (aluIn1 | aluIn2);
+	3'b111: aluOut = (aluIn1 & aluIn2);	
+      endcase
+   end
+
+   // The predicate for branch instructions
+   reg takeBranch;
+   always @(*) begin
+      case(funct3)
+	3'b000: takeBranch = EQ;
+	3'b001: takeBranch = !EQ;
+	3'b100: takeBranch = LT;
+	3'b101: takeBranch = !LT;
+	3'b110: takeBranch = LTU;
+	3'b111: takeBranch = !LTU;
+	default: takeBranch = 1'b0;
+      endcase
+   end
+   
+
+   // Address computation
+   // An adder used to compute branch address, JAL address and AUIPC.
+   // branch->PC+Bimm    AUIPC->PC+Uimm    JAL->PC+Jimm
+   // Equivalent to PCplusImm = PC + (isJAL ? Jimm : isAUIPC ? Uimm : Bimm)
+   wire [31:0] PCplusImm = PC + ( instr[3] ? Jimm[31:0] :
+				  instr[4] ? Uimm[31:0] :
+				             Bimm[31:0] );
+   wire [31:0] PCplus4 = PC+4;
+   
+   wire [31:0] nextPC = ((isBranch && takeBranch) || isJAL) ? PCplusImm   :
+	                                  isJALR   ? {aluPlus[31:1],1'b0} :
+	                                             PCplus4;
+
+   wire [31:0] loadstore_addr = rs1 + (isStore ? Simm : Iimm);
+
+
+   // register write back
+   assign writeBackData = (isJAL || isJALR) ? PCplus4   :
+			      isLUI         ? Uimm      :
+			      isAUIPC       ? PCplusImm :
+			      isLoad        ? LOAD_data :
+			                      aluOut;
+
+   assign writeBackEn = (state==EXECUTE && !isBranch && !isStore && !isLoad) ||
+			(state==WAIT_DATA) ;
+   
+   
+   // Load
+   // All memory accesses are aligned on 32 bits boundary. For this
+   // reason, we need some circuitry that does unaligned halfword
+   // and byte load/store, based on:
+   // - funct3[1:0]:  00->byte 01->halfword 10->word
+   // - mem_addr[1:0]: indicates which byte/halfword is accessed
+
+   wire mem_byteAccess     = funct3[1:0] == 2'b00;
+   wire mem_halfwordAccess = funct3[1:0] == 2'b01;
+
+
+   wire [15:0] LOAD_halfword =
+	       loadstore_addr[1] ? mem_rdata[31:16] : mem_rdata[15:0];
+
+   wire  [7:0] LOAD_byte =
+	       loadstore_addr[0] ? LOAD_halfword[15:8] : LOAD_halfword[7:0];
+
+   // LOAD, in addition to funct3[1:0], LOAD depends on:
+   // - funct3[2] (instr[14]): 0->do sign expansion   1->no sign expansion
+   wire LOAD_sign =
+	!funct3[2] & (mem_byteAccess ? LOAD_byte[7] : LOAD_halfword[15]);
+
+   wire [31:0] LOAD_data =
+         mem_byteAccess ? {{24{LOAD_sign}},     LOAD_byte} :
+     mem_halfwordAccess ? {{16{LOAD_sign}}, LOAD_halfword} :
+                          mem_rdata ;
+
+   // Store
+   // ------------------------------------------------------------------------
+
+   assign mem_wdata[ 7: 0] = rs2[7:0];
+   assign mem_wdata[15: 8] = loadstore_addr[0] ? rs2[7:0]  : rs2[15: 8];
+   assign mem_wdata[23:16] = loadstore_addr[1] ? rs2[7:0]  : rs2[23:16];
+   assign mem_wdata[31:24] = loadstore_addr[0] ? rs2[7:0]  :
+			     loadstore_addr[1] ? rs2[15:8] : rs2[31:24];
+
+   // The memory write mask:
+   //    1111                     if writing a word
+   //    0011 or 1100             if writing a halfword
+   //                                (depending on loadstore_addr[1])
+   //    0001, 0010, 0100 or 1000 if writing a byte
+   //                                (depending on loadstore_addr[1:0])
+
+   wire [3:0] STORE_wmask =
+	      mem_byteAccess      ?
+	            (loadstore_addr[1] ?
+		          (loadstore_addr[0] ? 4'b1000 : 4'b0100) :
+		          (loadstore_addr[0] ? 4'b0010 : 4'b0001)
+                    ) :
+	      mem_halfwordAccess ?
+	            (loadstore_addr[1] ? 4'b1100 : 4'b0011) :
+              4'b1111;
+
+   
+   
+   // The state machine
+   localparam FETCH_INSTR = 0;
+   localparam WAIT_INSTR  = 1;
+   localparam FETCH_REGS  = 2;
+   localparam EXECUTE     = 3;
+   localparam LOAD        = 4;
+   localparam WAIT_DATA   = 5;
+   localparam STORE       = 6;
+   reg [2:0] state = FETCH_INSTR;
+   
+   always @(posedge clk) begin
+      if(!resetn) begin
+	 PC    <= 0;
+	 state <= FETCH_INSTR;
+      end else begin
+	 if(writeBackEn && rdId != 0) begin
+	    RegisterBank[rdId] <= writeBackData;
+	    // For displaying what happens.
+	    if(rdId == 10) begin
+	       x10 <= writeBackData;
+	    end
+	 end
+	 case(state)
+	   FETCH_INSTR: begin
+	      state <= WAIT_INSTR;
+	   end
+	   WAIT_INSTR: begin
+	      instr <= mem_rdata;
+	      state <= FETCH_REGS;
+	   end
+	   FETCH_REGS: begin
+	      rs1 <= RegisterBank[rs1Id];
+	      rs2 <= RegisterBank[rs2Id];
+	      state <= EXECUTE;
+	   end
+	   EXECUTE: begin
+	      if(!isSYSTEM) begin
+		 PC <= nextPC;
+	      end
+	      state <= isLoad  ? LOAD  : 
+		       isStore ? STORE : 
+		       FETCH_INSTR;
+	   end
+	   LOAD: begin
+	      state <= WAIT_DATA;
+	   end
+	   WAIT_DATA: begin
+	      state <= FETCH_INSTR;
+	   end
+	   STORE: begin
+	      state <= FETCH_INSTR;
+	   end
+	 endcase 
+      end
+   end
+
+   
+   assign mem_addr = (state == WAIT_INSTR || state == FETCH_INSTR) ?
+		     PC : loadstore_addr ;
+   assign mem_rstrb = (state == FETCH_INSTR || state == LOAD);
+   assign mem_wmask = {4{(state == STORE)}} & STORE_wmask;
+   
+endmodule
+
+
+module top (
+    input  clk_i,      // system clock 
+    input  rst_i,      // reset button
+    output [5:0] led,  // system LEDs
+    input  RXD,        // UART receive
+    output TXD         // UART transmit
+);
+
+   wire clk;
+   wire resetn;
+
+   wire [31:0] mem_addr;
+   wire [31:0] mem_rdata;
+   wire mem_rstrb;
+   wire [31:0] mem_wdata;
+   wire [3:0]  mem_wmask;
+   
+   Memory RAM(
+      .clk(clk),
+      .mem_addr(mem_addr),
+      .mem_rdata(mem_rdata),
+      .mem_rstrb(mem_rstrb),
+      .mem_wdata(mem_wdata),
+      .mem_wmask(mem_wmask)
+   );
+
+   wire [31:0] x10;
+
+   Processor CPU(
+      .clk(clk),
+      .resetn(resetn),		 
+      .mem_addr(mem_addr),
+      .mem_rdata(mem_rdata),
+      .mem_rstrb(mem_rstrb),
+      .mem_wdata(mem_wdata),
+      .mem_wmask(mem_wmask),		 
+      .x10(x10)		 
+   );
+
+
+   // Gearbox and reset circuitry.
+   Clockworks #(
+	 .SLOW(0)    //Specifying a value other than zero here may result in
+				 // nextpnr being unable to route the clock for some boards. BUGFIX is under development. 
+	) CW (
+     .CLK(clk_i),
+     .RESET(rst_i),
+     .clk(clk),
+     .resetn(resetn)
+   );
+
+   assign led = ~x10[5:0];
+   assign TXD  = 1'b0; // not used for now
+   
+endmodule
+

--- a/examples/himbaechel/femto-riscv-18.v
+++ b/examples/himbaechel/femto-riscv-18.v
@@ -1,0 +1,592 @@
+/**
+ * Step 18: Creating a RISC-V processor
+ * Mandelbrot in the terminal
+ *
+ * Copyright (c) 2020, Bruno Levy
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+`default_nettype none
+`include "clockworks.v"
+`include "emitter_uart.v"
+
+module Memory (
+   input             clk,
+   input      [31:0] mem_addr,  // address to be read
+   output reg [31:0] mem_rdata, // data read from memory
+   input   	     mem_rstrb, // goes high when processor wants to read
+   input      [31:0] mem_wdata, // data to be written
+   input      [3:0]  mem_wmask	// masks for writing the 4 bytes (1=write byte)
+);
+
+   reg [31:0] MEM [0:1535]; // 1536 4-bytes words = 6 Kb of RAM in total
+
+   localparam slow_bit=17;
+
+   // Memory-mapped IO in IO page, 1-hot addressing in word address.   
+   localparam IO_LEDS_bit      = 0;  // W five leds
+   localparam IO_UART_DAT_bit  = 1;  // W data to send (8 bits) 
+   localparam IO_UART_CNTL_bit = 2;  // R status. bit 9: busy sending
+
+   // Converts an IO_xxx_bit constant into an offset in IO page.
+   function [31:0] IO_BIT_TO_OFFSET;
+      input [31:0] bitid;
+      begin
+	 IO_BIT_TO_OFFSET = 1 << (bitid + 2);
+      end
+   endfunction
+   
+`include "riscv_assembly.v"
+
+   `define mandel_shift 10
+   `define mandel_mul (1 << `mandel_shift)
+   `define xmin (-2*`mandel_mul)
+   `define xmax ( 2*`mandel_mul)
+   `define ymin (-2*`mandel_mul)
+   `define ymax ( 2*`mandel_mul)	
+   `define dx ((`xmax-`xmin)/80)
+   `define dy ((`ymax-`ymin)/80)
+   `define norm_max (4 << `mandel_shift)
+   
+   integer    mandelstart_ = 12;
+   integer    blink_       = 16;
+   integer    loop_y_      = 76;
+   integer    loop_x_      = 84;
+   integer    loop_Z_      = 96;
+   integer    exit_Z_      = 188;
+   integer    wait_        = 264;
+   integer    wait_L0_     = 272;
+   integer    putc_        = 284; 
+   integer    putc_L0_     = 292;
+   integer    mulsi3_      = 308;
+   integer    mulsi3_L0_   = 316;
+   integer    mulsi3_L1_   = 328;
+   
+   integer    colormap_    = 344;
+
+   // X,Y         : s0,s1
+   // Cr,Ci       : s2,s3
+   // Zr,Zi       : s4,s5
+   // Zrr,2Zri,Zii: s6,s7,s8
+   // cnt: s10
+   // 128: s11
+   
+   initial begin
+      LI(sp,32'h1800);   // End of RAM, 6kB
+      LI(gp,32'h400000); // IO page
+
+   Label(mandelstart_);
+
+      // Blink 5 times.
+      LI(s0,5);      
+   Label(blink_);
+      LI(a0,5);
+      SW(a0,gp,IO_BIT_TO_OFFSET(IO_LEDS_bit));
+      CALL(LabelRef(wait_));
+      LI(a0,10);
+      SW(a0,gp,IO_BIT_TO_OFFSET(IO_LEDS_bit));
+      CALL(LabelRef(wait_));
+      ADDI(s0,s0,-1);
+      BNEZ(s0,LabelRef(blink_));
+      LI(a0,0);
+      SW(a0,gp,IO_BIT_TO_OFFSET(IO_LEDS_bit));      
+      
+      
+      LI(s1,0);
+      LI(s3,`xmin);
+      LI(s11,80);
+      
+   Label(loop_y_);
+      LI(s0,0);
+      LI(s2,`ymin);
+
+   Label(loop_x_);
+      MV(s4,s2); // Z <- C
+      MV(s5,s3);
+
+      LI(s10,9); // iter <- 9
+
+   Label(loop_Z_);
+      MV(a0,s4); // Zrr  <- (Zr*Zr) >> mandel_shift
+      MV(a1,s4);
+      CALL(LabelRef(mulsi3_));
+      SRLI(s6,a0,`mandel_shift);
+      MV(a0,s4); // Zri <- (Zr*Zi) >> (mandel_shift-1)
+      MV(a1,s5);
+      CALL(LabelRef(mulsi3_));
+      SRAI(s7,a0,`mandel_shift-1);
+      MV(a0,s5); // Zii <- (Zi*Zi) >> (mandel_shift)
+      MV(a1,s5);
+      CALL(LabelRef(mulsi3_));
+      SRLI(s8,a0,`mandel_shift);
+      SUB(s4,s6,s8); // Zr <- Zrr - Zii + Cr  
+      ADD(s4,s4,s2);
+      ADD(s5,s7,s3); // Zi <- 2Zri + Cr
+
+      ADD(s6,s6,s8); // if norm > norm max, exit loop
+      LI(s7,`norm_max);
+      BGT(s6,s7,LabelRef(exit_Z_));
+      
+      ADDI(s10,s10,-1);  // iter--, loop if non-zero
+      BNEZ(s10,LabelRef(loop_Z_));
+      
+   Label(exit_Z_);
+      LI(a0,colormap_);
+      ADD(a0,a0,s10);
+      LBU(a0,a0,0);
+      CALL(LabelRef(putc_));
+
+      ADDI(s0,s0,1);
+      ADDI(s2,s2,`dx);
+      BNE(s0,s11,LabelRef(loop_x_));
+
+      LI(a0," ");
+      CALL(LabelRef(putc_));
+      LI(a0,"\n");
+      CALL(LabelRef(putc_));      
+
+      ADDI(s1,s1,1);
+      ADDI(s3,s3,`dy);
+      BNE(s1,s11,LabelRef(loop_y_));
+
+      
+      J(LabelRef(mandelstart_));
+      
+      EBREAK(); // I systematically keep it before functions
+                // in case I decide to remove the loop...
+
+   Label(wait_);
+      LI(t0,1);
+      SLLI(t0,t0,slow_bit);
+   Label(wait_L0_);
+      ADDI(t0,t0,-1);
+      BNEZ(t0,LabelRef(wait_L0_));
+      RET();
+
+   Label(putc_);
+      // Send character to UART
+      SW(a0,gp,IO_BIT_TO_OFFSET(IO_UART_DAT_bit));
+      // Read UART status, and loop until bit 9 (busy sending)
+      // is zero.
+      LI(t0,1<<9);
+   Label(putc_L0_);
+      LW(t1,gp,IO_BIT_TO_OFFSET(IO_UART_CNTL_bit));     
+      AND(t1,t1,t0);
+      BNEZ(t1,LabelRef(putc_L0_));
+      RET();
+
+      // Mutiplication routine,
+      // Input in a0 and a1
+      // Result in a0
+   Label(mulsi3_);
+      MV(a2,a0);
+      LI(a0,0);
+   Label(mulsi3_L0_); 
+      ANDI(a3,a1,1);
+      BEQZ(a3,LabelRef(mulsi3_L1_)); 
+      ADD(a0,a0,a2);
+   Label(mulsi3_L1_);
+      SRLI(a1,a1,1);
+      SLLI(a2,a2,1);
+      BNEZ(a1,LabelRef(mulsi3_L0_));
+      RET();
+
+   Label(colormap_);
+      DATAB(" ",".",",",":");
+      DATAB(";","o","x","%");
+      DATAB("#","@", 0 , 0 );            
+      endASM();
+   end
+
+   wire [29:0] word_addr = mem_addr[31:2];
+   
+   always @(posedge clk) begin
+      if(mem_rstrb) begin
+         mem_rdata <= MEM[word_addr];
+      end
+      if(mem_wmask[0]) MEM[word_addr][ 7:0 ] <= mem_wdata[ 7:0 ];
+      if(mem_wmask[1]) MEM[word_addr][15:8 ] <= mem_wdata[15:8 ];
+      if(mem_wmask[2]) MEM[word_addr][23:16] <= mem_wdata[23:16];
+      if(mem_wmask[3]) MEM[word_addr][31:24] <= mem_wdata[31:24];	 
+   end
+endmodule
+
+module Processor (
+    input 	  clk,
+    input 	  resetn,
+    output [31:0] mem_addr, 
+    input [31:0]  mem_rdata, 
+    output 	  mem_rstrb,
+    output [31:0] mem_wdata,
+    output [3:0]  mem_wmask
+);
+
+   reg [31:0] PC=0;        // program counter
+   reg [31:0] instr;       // current instruction
+
+   // See the table P. 105 in RISC-V manual
+   
+   // The 10 RISC-V instructions
+   wire isALUreg  =  (instr[6:0] == 7'b0110011); // rd <- rs1 OP rs2   
+   wire isALUimm  =  (instr[6:0] == 7'b0010011); // rd <- rs1 OP Iimm
+   wire isBranch  =  (instr[6:0] == 7'b1100011); // if(rs1 OP rs2) PC<-PC+Bimm
+   wire isJALR    =  (instr[6:0] == 7'b1100111); // rd <- PC+4; PC<-rs1+Iimm
+   wire isJAL     =  (instr[6:0] == 7'b1101111); // rd <- PC+4; PC<-PC+Jimm
+   wire isAUIPC   =  (instr[6:0] == 7'b0010111); // rd <- PC + Uimm
+   wire isLUI     =  (instr[6:0] == 7'b0110111); // rd <- Uimm   
+   wire isLoad    =  (instr[6:0] == 7'b0000011); // rd <- mem[rs1+Iimm]
+   wire isStore   =  (instr[6:0] == 7'b0100011); // mem[rs1+Simm] <- rs2
+   wire isSYSTEM  =  (instr[6:0] == 7'b1110011); // special
+
+   // The 5 immediate formats
+   wire [31:0] Uimm={    instr[31],   instr[30:12], {12{1'b0}}};
+   wire [31:0] Iimm={{21{instr[31]}}, instr[30:20]};
+   wire [31:0] Simm={{21{instr[31]}}, instr[30:25],instr[11:7]};
+   wire [31:0] Bimm={{20{instr[31]}}, instr[7],instr[30:25],instr[11:8],1'b0};
+   wire [31:0] Jimm={{12{instr[31]}}, instr[19:12],instr[20],instr[30:21],1'b0};
+
+   // Source and destination registers
+   wire [4:0] rs1Id = instr[19:15];
+   wire [4:0] rs2Id = instr[24:20];
+   wire [4:0] rdId  = instr[11:7];
+   
+   // function codes
+   wire [2:0] funct3 = instr[14:12];
+   wire [6:0] funct7 = instr[31:25];
+   
+   // The registers bank
+`ifdef FORCE_BRAM
+   (* ram_style = "block" *)
+`endif
+   reg [31:0] RegisterBank [0:31];
+   reg [31:0] rs1; // value of source
+   reg [31:0] rs2; //  registers.
+   wire [31:0] writeBackData; // data to be written to rd
+   wire        writeBackEn;   // asserted if data should be written to rd
+
+   // The ALU
+   wire [31:0] aluIn1 = rs1;
+   wire [31:0] aluIn2 = isALUreg | isBranch ? rs2 : Iimm;
+
+   wire [4:0] shamt = isALUreg ? rs2[4:0] : instr[24:20]; // shift amount
+
+   // The adder is used by both arithmetic instructions and JALR.
+   wire [31:0] aluPlus = aluIn1 + aluIn2;
+
+   // Use a single 33 bits subtract to do subtraction and all comparisons
+   // (trick borrowed from swapforth/J1)
+   wire [32:0] aluMinus = {1'b1, ~aluIn2} + {1'b0,aluIn1} + 33'b1;
+   wire        LT  = (aluIn1[31] ^ aluIn2[31]) ? aluIn1[31] : aluMinus[32];
+   wire        LTU = aluMinus[32];
+   wire        EQ  = (aluMinus[31:0] == 0);
+
+   // Flip a 32 bit word. Used by the shifter (a single shifter for
+   // left and right shifts, saves silicium !)
+   function [31:0] flip32;
+      input [31:0] x;
+      flip32 = {x[ 0], x[ 1], x[ 2], x[ 3], x[ 4], x[ 5], x[ 6], x[ 7], 
+		x[ 8], x[ 9], x[10], x[11], x[12], x[13], x[14], x[15], 
+		x[16], x[17], x[18], x[19], x[20], x[21], x[22], x[23],
+		x[24], x[25], x[26], x[27], x[28], x[29], x[30], x[31]};
+   endfunction
+
+   wire [31:0] shifter_in = (funct3 == 3'b001) ? flip32(aluIn1) : aluIn1;
+   
+   /* verilator lint_off WIDTH */
+   wire [31:0] shifter = 
+               $signed({instr[30] & aluIn1[31], shifter_in}) >>> aluIn2[4:0];
+   /* verilator lint_on WIDTH */
+
+   wire [31:0] leftshift = flip32(shifter);
+   
+
+   
+   // ADD/SUB/ADDI: 
+   // funct7[5] is 1 for SUB and 0 for ADD. We need also to test instr[5]
+   // to make the difference with ADDI
+   //
+   // SRLI/SRAI/SRL/SRA: 
+   // funct7[5] is 1 for arithmetic shift (SRA/SRAI) and 
+   // 0 for logical shift (SRL/SRLI)
+   reg [31:0]  aluOut;
+   always @(*) begin
+      case(funct3)
+	3'b000: aluOut = (funct7[5] & instr[5]) ? aluMinus[31:0] : aluPlus;
+	3'b001: aluOut = leftshift;
+	3'b010: aluOut = {31'b0, LT};
+	3'b011: aluOut = {31'b0, LTU};
+	3'b100: aluOut = (aluIn1 ^ aluIn2);
+	3'b101: aluOut = shifter;
+	3'b110: aluOut = (aluIn1 | aluIn2);
+	3'b111: aluOut = (aluIn1 & aluIn2);	
+      endcase
+   end
+
+   // The predicate for branch instructions
+   reg takeBranch;
+   always @(*) begin
+      case(funct3)
+	3'b000: takeBranch = EQ;
+	3'b001: takeBranch = !EQ;
+	3'b100: takeBranch = LT;
+	3'b101: takeBranch = !LT;
+	3'b110: takeBranch = LTU;
+	3'b111: takeBranch = !LTU;
+	default: takeBranch = 1'b0;
+      endcase
+   end
+   
+
+   // Address computation
+   // An adder used to compute branch address, JAL address and AUIPC.
+   // branch->PC+Bimm    AUIPC->PC+Uimm    JAL->PC+Jimm
+   // Equivalent to PCplusImm = PC + (isJAL ? Jimm : isAUIPC ? Uimm : Bimm)
+   wire [31:0] PCplusImm = PC + ( instr[3] ? Jimm[31:0] :
+				  instr[4] ? Uimm[31:0] :
+				             Bimm[31:0] );
+   wire [31:0] PCplus4 = PC+4;
+   
+   // register write back
+   assign writeBackData = (isJAL || isJALR) ? PCplus4   :
+			      isLUI         ? Uimm      :
+			      isAUIPC       ? PCplusImm :
+			      isLoad        ? LOAD_data :
+			                      aluOut;
+
+   wire [31:0] nextPC = ((isBranch && takeBranch) || isJAL) ? PCplusImm   :
+	                                  isJALR   ? {aluPlus[31:1],1'b0} :
+	                                             PCplus4;
+
+   wire [31:0] loadstore_addr = rs1 + (isStore ? Simm : Iimm);
+   
+   // Load
+   // All memory accesses are aligned on 32 bits boundary. For this
+   // reason, we need some circuitry that does unaligned halfword
+   // and byte load/store, based on:
+   // - funct3[1:0]:  00->byte 01->halfword 10->word
+   // - mem_addr[1:0]: indicates which byte/halfword is accessed
+
+   wire mem_byteAccess     = funct3[1:0] == 2'b00;
+   wire mem_halfwordAccess = funct3[1:0] == 2'b01;
+
+
+   wire [15:0] LOAD_halfword =
+	       loadstore_addr[1] ? mem_rdata[31:16] : mem_rdata[15:0];
+
+   wire  [7:0] LOAD_byte =
+	       loadstore_addr[0] ? LOAD_halfword[15:8] : LOAD_halfword[7:0];
+
+   // LOAD, in addition to funct3[1:0], LOAD depends on:
+   // - funct3[2] (instr[14]): 0->do sign expansion   1->no sign expansion
+   wire LOAD_sign =
+	!funct3[2] & (mem_byteAccess ? LOAD_byte[7] : LOAD_halfword[15]);
+
+   wire [31:0] LOAD_data =
+         mem_byteAccess ? {{24{LOAD_sign}},     LOAD_byte} :
+     mem_halfwordAccess ? {{16{LOAD_sign}}, LOAD_halfword} :
+                          mem_rdata ;
+
+   // Store
+   // ------------------------------------------------------------------------
+
+   assign mem_wdata[ 7: 0] = rs2[7:0];
+   assign mem_wdata[15: 8] = loadstore_addr[0] ? rs2[7:0]  : rs2[15: 8];
+   assign mem_wdata[23:16] = loadstore_addr[1] ? rs2[7:0]  : rs2[23:16];
+   assign mem_wdata[31:24] = loadstore_addr[0] ? rs2[7:0]  :
+			     loadstore_addr[1] ? rs2[15:8] : rs2[31:24];
+
+   // The memory write mask:
+   //    1111                     if writing a word
+   //    0011 or 1100             if writing a halfword
+   //                                (depending on loadstore_addr[1])
+   //    0001, 0010, 0100 or 1000 if writing a byte
+   //                                (depending on loadstore_addr[1:0])
+
+   wire [3:0] STORE_wmask =
+	      mem_byteAccess      ?
+	            (loadstore_addr[1] ?
+		          (loadstore_addr[0] ? 4'b1000 : 4'b0100) :
+		          (loadstore_addr[0] ? 4'b0010 : 4'b0001)
+                    ) :
+	      mem_halfwordAccess ?
+	            (loadstore_addr[1] ? 4'b1100 : 4'b0011) :
+              4'b1111;
+   
+   // The state machine
+   localparam FETCH_INSTR = 0;
+   localparam WAIT_INSTR  = 1;
+   localparam FETCH_REGS  = 2;
+   localparam EXECUTE     = 3;
+   localparam LOAD        = 4;
+   localparam WAIT_DATA   = 5;
+   localparam STORE       = 6;
+   reg [2:0] state = FETCH_INSTR;
+   
+   always @(posedge clk) begin
+      if(!resetn) begin
+	 PC    <= 0;
+	 state <= FETCH_INSTR;
+      end else begin
+	 if(writeBackEn && rdId != 0) begin
+	    RegisterBank[rdId] <= writeBackData;
+	 end
+	 case(state)
+	   FETCH_INSTR: begin
+	      state <= WAIT_INSTR;
+	   end
+	   WAIT_INSTR: begin
+	      instr <= mem_rdata;
+	      state <= FETCH_REGS;
+	   end
+	   FETCH_REGS: begin
+	      rs1 <= RegisterBank[rs1Id];
+	      rs2 <= RegisterBank[rs2Id];
+	      state <= EXECUTE;
+	   end
+	   EXECUTE: begin
+	      if(!isSYSTEM) begin
+		 PC <= nextPC;
+	      end
+	      state <= isLoad  ? LOAD  : 
+		       isStore ? STORE : 
+		       FETCH_INSTR;
+	   end
+	   LOAD: begin
+	      state <= WAIT_DATA;
+	   end
+	   WAIT_DATA: begin
+	      state <= FETCH_INSTR;
+	   end
+	   STORE: begin
+	      state <= FETCH_INSTR;
+	   end
+	 endcase 
+      end
+   end
+
+   assign writeBackEn = (state==EXECUTE && !isBranch && !isStore) ||
+			(state==WAIT_DATA) ;
+   
+   assign mem_addr = (state == WAIT_INSTR || state == FETCH_INSTR) ?
+		     PC : loadstore_addr ;
+   assign mem_rstrb = (state == FETCH_INSTR || state == LOAD);
+   assign mem_wmask = {4{(state == STORE)}} & STORE_wmask;
+   
+endmodule
+
+
+module top (
+    input 	     clk_i, // system clock 
+    input 	     rst_i, // reset button
+    output  [5:0] led,  // system LEDs
+    input 	     RXD,   // UART receive
+    output 	     TXD    // UART transmit
+);
+
+   wire clk;
+   wire resetn;
+
+   wire [31:0] mem_addr;
+   wire [31:0] mem_rdata;
+   wire mem_rstrb;
+   wire [31:0] mem_wdata;
+   wire [3:0]  mem_wmask;
+
+   Processor CPU(
+      .clk(clk),
+      .resetn(resetn),		 
+      .mem_addr(mem_addr),
+      .mem_rdata(mem_rdata),
+      .mem_rstrb(mem_rstrb),
+      .mem_wdata(mem_wdata),
+      .mem_wmask(mem_wmask)
+   );
+   
+   wire [31:0] RAM_rdata;
+   wire [29:0] mem_wordaddr = mem_addr[31:2];
+   wire isIO  = mem_addr[22];
+   wire isRAM = !isIO;
+   wire mem_wstrb = |mem_wmask;
+   
+   Memory RAM(
+      .clk(clk),
+      .mem_addr(mem_addr),
+      .mem_rdata(RAM_rdata),
+      .mem_rstrb(isRAM & mem_rstrb),
+      .mem_wdata(mem_wdata),
+      .mem_wmask({4{isRAM}}&mem_wmask)
+   );
+
+
+   // Memory-mapped IO in IO page, 1-hot addressing in word address.   
+   localparam IO_LEDS_bit      = 0;  // W five leds
+   localparam IO_UART_DAT_bit  = 1;  // W data to send (8 bits) 
+   localparam IO_UART_CNTL_bit = 2;  // R status. bit 9: busy sending
+   
+   always @(posedge clk) begin
+      if(isIO & mem_wstrb & mem_wordaddr[IO_LEDS_bit]) begin
+		led <= mem_wdata;
+      end
+   end
+
+   wire uart_valid = isIO & mem_wstrb & mem_wordaddr[IO_UART_DAT_bit];
+   wire uart_ready;
+   
+   corescore_emitter_uart #(
+      .clk_freq_hz(`CPU_FREQ*1000000),
+      .baud_rate(`BAUD_RATE)			    
+   ) UART(
+      .i_clk(clk),
+      .i_rst(!resetn),
+      .i_data(mem_wdata[7:0]),
+      .i_valid(uart_valid),
+      .o_ready(uart_ready),
+      .o_uart_tx(TXD)      			       
+   );
+
+   wire [31:0] IO_rdata = 
+	       mem_wordaddr[IO_UART_CNTL_bit] ? { 22'b0, !uart_ready, 9'b0}
+	                                      : 32'b0;
+   
+   assign mem_rdata = isRAM ? RAM_rdata :
+	                      IO_rdata ;
+   
+   
+   // Gearbox and reset circuitry.
+   Clockworks #(
+	 .SLOW(0)    //Specifying a value other than zero here may result in
+				 // nextpnr being unable to route the clock for some boards. BUGFIX is under development. 
+   ) CW (
+     .CLK(clk_i),
+     .RESET(rst_i),
+     .clk(clk),
+     .resetn(resetn)
+   );
+
+endmodule
+

--- a/examples/himbaechel/riscv_assembly.v
+++ b/examples/himbaechel/riscv_assembly.v
@@ -1,0 +1,808 @@
+/*
+ * A simple assembler for RiscV written in VERILOG.
+ * See table page 104 of RiscV instruction manual.
+ * Bruno Levy, March 2022
+ */
+
+// Machine code will be generated in MEM,
+// starting from address 0 (can be changed below,
+// initial value of memPC).
+//
+// Example:
+//
+// module MyModule( my inputs, my outputs ...);
+//    ...
+//    reg [31:0] MEM [0:255]; 
+//    `include "riscv_assembly.v" // yes, needs to be included from here.
+//    integer L0_;
+//    initial begin
+//                  ADD(x1,x0,x0);
+//                  ADDI(x2,x0,32);
+//      Label(L0_); ADDI(x1,x1,1); 
+//                  BNE(x1, x2, LabelRef(L0_));
+//                  EBREAK();
+//    end
+//   1) simulate with icarus, it will complain about uninitialized labels,
+//      and will display for each Label() statement the address to be used
+//      (in the present case, it is 8)
+//   2) replace the declaration of the label:
+//      integer L0_ = 8;
+//      re-simulate with icarus
+//      If you made an error, it will be detected
+//   3) synthesize with yosys
+// (if you do not use labels, you can synthesize directly, of course...)
+//
+//
+// You can change the address where code is generated
+//   by assigning to memPC (needs to be a word boundary).
+//
+// NOTE: to be checked, LUI, AUIPC take as argument
+//     pre-shifted constant, unlike in GNU assembly
+
+integer memPC;
+initial memPC = 0;
+
+/***************************************************************************/
+
+/*
+ * Register names.
+ * Looks stupid, but makes assembly code more legible (without it,
+ * one does not make the difference between immediate values and 
+ * register ids).
+ */ 
+
+localparam x0 = 0, x1 = 1, x2 = 2, x3 = 3, x4 = 4, x5 = 5, x6 = 6, x7 = 7, 
+           x8 = 8, x9 = 9, x10=10, x11=11, x12=12, x13=13, x14=14, x15=15,
+           x16=16, x17=17, x18=18, x19=19, x20=20, x21=21, x22=22, x23=23,
+           x24=24, x25=25, x26=26, x27=27, x28=28, x29=29, x30=30, x31=31;
+
+
+// add x0,x0,x0   
+localparam [31:0] NOP_CODEOP = 32'b0000000_00000_00000_000_00000_0110011; 
+
+/***************************************************************************/
+
+/*
+ * R-Type instructions.
+ * rd <- rs1 OP rs2
+ */
+
+task RType;
+   input [6:0] opcode;
+   input [4:0] rd;   
+   input [4:0] rs1;
+   input [4:0] rs2;
+   input [2:0] funct3;
+   input [6:0] funct7;
+   begin
+      MEM[memPC[31:2]] = {funct7, rs2, rs1, funct3, rd, opcode};
+      memPC = memPC + 4;
+   end
+endtask
+
+task ADD;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b000, 7'b0000000);
+endtask
+   
+task SUB;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b000, 7'b0100000);
+endtask
+
+task SLL;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b001, 7'b0000000);
+endtask
+
+task SLT;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b010, 7'b0000000);
+endtask
+   
+task SLTU;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b011, 7'b0000000);
+endtask
+
+task XOR;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b100, 7'b0000000);
+endtask
+
+task SRL;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b101, 7'b0000000);
+endtask
+
+task SRA;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b101, 7'b0100000);
+endtask
+
+task OR;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b110, 7'b0000000);
+endtask
+
+task AND;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [4:0] rs2;
+   RType(7'b0110011, rd, rs1, rs2, 3'b111, 7'b0000000);
+endtask
+
+/***************************************************************************/
+
+/*
+ * I-Type instructions.
+ * rd <- rs1 OP imm
+ */
+   
+task IType;
+   input [6:0]  opcode;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   input [2:0]  funct3;
+   begin
+      MEM[memPC[31:2]] = {imm[11:0], rs1, funct3, rd, opcode};
+      memPC = memPC + 4;
+   end
+endtask
+
+task ADDI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0010011, rd, rs1, imm, 3'b000);
+   end
+endtask
+
+task SLTI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0010011, rd, rs1, imm, 3'b010);
+   end
+endtask
+
+task SLTIU;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0010011, rd, rs1, imm, 3'b011);
+   end
+endtask
+
+task XORI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0010011, rd, rs1, imm, 3'b100);
+   end
+endtask
+
+task ORI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0010011, rd, rs1, imm, 3'b110);
+   end
+endtask
+
+task ANDI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0010011, rd, rs1, imm, 3'b111);
+   end
+endtask
+
+// The three shifts, SLLI, SRLI, SRAI, encoded in RType format
+// (rs2 is replaced with shift amount=imm[4:0])   
+   
+task SLLI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      RType(7'b0010011, rd, rs1, imm[4:0], 3'b001, 7'b0000000);
+   end
+endtask
+
+task SRLI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      RType(7'b0010011, rd, rs1, imm[4:0], 3'b101, 7'b0000000);
+   end
+endtask
+
+task SRAI;
+   input [4:0]  rd;   
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      RType(7'b0010011, rd, rs1, imm[4:0], 3'b101, 7'b0100000);
+   end
+endtask
+
+/***************************************************************************/
+
+/*
+ * Jumps (JAL and JALR)
+ */
+
+task JType;
+   input [6:0]  opcode;
+   input [4:0]  rd;
+   input [31:0] imm;
+   begin
+      MEM[memPC[31:2]] = {imm[20], imm[10:1], imm[11], imm[19:12], rd, opcode};
+      memPC = memPC + 4;
+   end
+endtask
+   
+task JAL;
+   input [4:0] rd;
+   input [31:0] imm;
+   begin
+      JType(7'b1101111, rd, imm);
+   end
+endtask 
+
+// JALR is encoded in the IType format.
+   
+task JALR;
+   input [4:0] rd;
+   input [4:0] rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b1100111, rd, rs1, imm, 3'b000);
+   end
+endtask   
+
+/***************************************************************************/   
+
+/*
+ * Branch instructions.
+ */    
+   
+task BType;
+   input [6:0]  opcode;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   input [2:0]  funct3;
+   begin
+      MEM[memPC[31:2]] = {imm[12],imm[10:5], rs2, rs1, funct3, imm[4:1], imm[11], opcode};
+      memPC = memPC + 4;
+   end
+endtask
+
+task BEQ;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      BType(7'b1100011, rs1, rs2, imm, 3'b000);
+   end
+endtask
+
+task BNE;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      BType(7'b1100011, rs1, rs2, imm, 3'b001);
+   end
+endtask
+
+task BLT;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      BType(7'b1100011, rs1, rs2, imm, 3'b100);
+   end
+endtask
+
+task BGE;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      BType(7'b1100011, rs1, rs2, imm, 3'b101);
+   end
+endtask
+
+task BLTU;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      BType(7'b1100011, rs1, rs2, imm, 3'b110);
+   end
+endtask
+
+task BGEU;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      BType(7'b1100011, rs1, rs2, imm, 3'b111);
+   end
+endtask
+   
+/***************************************************************************/   
+
+/*
+ * LUI and AUIPC
+ */    
+
+task UType;
+   input [6:0]  opcode;
+   input [4:0]  rd;
+   input [31:0] imm;
+   begin
+      MEM[memPC[31:2]] = {imm[31:12], rd, opcode};
+      memPC = memPC + 4;
+   end
+endtask
+
+task LUI;
+   input [4:0]  rd;
+   input [31:0] imm;
+   begin
+      UType(7'b0110111, rd, imm);
+   end
+endtask
+
+task AUIPC;
+   input [4:0]  rd;
+   input [31:0] imm;
+   begin
+      UType(7'b0010111, rd, imm);
+   end
+endtask
+   
+/***************************************************************************/   
+
+/*
+ * Load instructions
+ */    
+
+task LB;
+   input [4:0]  rd;
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0000011, rd, rs1, imm, 3'b000);
+   end
+endtask      
+
+task LH;
+   input [4:0]  rd;
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0000011, rd, rs1, imm, 3'b001);
+   end
+endtask      
+   
+task LW;
+   input [4:0]  rd;
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0000011, rd, rs1, imm, 3'b010);
+   end
+endtask      
+
+task LBU;
+   input [4:0]  rd;
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0000011, rd, rs1, imm, 3'b100);
+   end
+endtask      
+
+task LHU;
+   input [4:0]  rd;
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      IType(7'b0000011, rd, rs1, imm, 3'b101);
+   end
+endtask      
+   
+/***************************************************************************/   
+
+/*
+ * Store instructions
+ */ 
+
+task SType;
+   input [6:0]  opcode;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   input [2:0]  funct3;
+   begin
+      MEM[memPC[31:2]] = {imm[11:5], rs2, rs1, funct3, imm[4:0], opcode};
+      memPC = memPC + 4;
+   end
+endtask
+
+// Note: in SB, SH, SW, rs1 and rs2 are swapped, to match assembly code:
+// for instance:
+//   
+//     rs2   rs1   
+//  sw ra, 0(sp)   
+   
+task SB;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      SType(7'b0100011, rs2, rs1, imm, 3'b000);
+   end
+endtask   
+
+task SH;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      SType(7'b0100011, rs2, rs1, imm, 3'b001);
+   end
+endtask   
+
+task SW;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      SType(7'b0100011, rs2, rs1, imm, 3'b010);
+   end
+endtask   
+   
+/***************************************************************************/   
+   
+/*
+ * SYSTEM instructions
+ */
+
+task FENCE;
+   input [3:0] pred;
+   input [3:0] succ;
+   begin
+      MEM[memPC[31:2]] = {4'b0000, pred, succ, 5'b00000, 3'b000, 5'b00000, 7'b1110011};
+      memPC = memPC + 4;
+   end
+endtask   
+
+task FENCE_I;
+   begin
+      MEM[memPC[31:2]] = {4'b0000, 4'b0000, 4'b0000, 5'b00000, 3'b001, 5'b00000, 7'b1110011};
+      memPC = memPC + 4;
+   end
+endtask   
+   
+task ECALL;
+   begin
+      MEM[memPC[31:2]] = {12'b000000000000, 5'b00000, 3'b000, 5'b00000, 7'b1110011};
+      memPC = memPC + 4;
+   end
+endtask   
+   
+task EBREAK;
+   begin
+      MEM[memPC[31:2]] = {12'b000000000001, 5'b00000, 3'b000, 5'b00000, 7'b1110011};
+      memPC = memPC + 4;
+   end
+endtask   
+
+task CSRRW;
+   input [4:0] rd;
+   input [11:0] csr;
+   input [4:0] rs1;
+   begin
+      MEM[memPC[31:2]] = {csr, rs1, 3'b001, rd, 7'b1110011};
+      memPC = memPC + 4;      
+   end
+endtask
+
+task CSRRS;
+   input [4:0] rd;
+   input [11:0] csr;
+   input [4:0] rs1;
+   begin
+      MEM[memPC[31:2]] = {csr, rs1, 3'b010, rd, 7'b1110011};
+      memPC = memPC + 4;      
+   end
+endtask
+
+task CSRRC;
+   input [4:0] rd;
+   input [11:0] csr;   
+   input [4:0] rs1;
+   begin
+      MEM[memPC[31:2]] = {csr, rs1, 3'b011, rd, 7'b1110011};
+      memPC = memPC + 4;      
+   end
+endtask
+
+task CSRRWI;
+   input [4:0] rd;
+   input [11:0] csr;
+   input [31:0] imm;
+   begin
+      MEM[memPC[31:2]] = {csr, imm[4:0], 3'b101, rd, 7'b1110011};
+      memPC = memPC + 4;      
+   end
+endtask
+
+task CSRRSI;
+   input [4:0] rd;
+   input [11:0] csr;
+   input [31:0] imm;
+   begin
+      MEM[memPC[31:2]] = {csr, imm[4:0], 3'b110, rd, 7'b1110011};
+      memPC = memPC + 4;      
+   end
+endtask
+
+task CSRRCI;
+   input [4:0] rd;
+   input [11:0] csr;
+   input [31:0] imm;
+   begin
+      MEM[memPC[31:2]] = {csr, imm[4:0], 3'b111, rd, 7'b1110011};
+      memPC = memPC + 4;      
+   end
+endtask
+   
+/***************************************************************************/   
+
+/*
+ * Labels.
+ * Example of usage:
+ *  
+ *                   ADD(x1,x0,x0);
+ *       Label(L0_); ADDI(x1,x1,1); 
+ *                   JAL(x0, LabelRef(L0_));
+ */
+
+   integer ASMerror=0;
+   
+   task Label;
+      inout integer L;
+      begin
+`ifdef BENCH
+	if(L[0] === 1'bx) begin
+	   $display("Missing label initialization");
+	   ASMerror = 1;
+	end else if(L != memPC) begin
+	   $display("Incorrect label initialization");
+	   $display("Expected: %0d    Got: %0d",memPC,L);
+	   ASMerror = 1;
+	end
+	$display("Label:",memPC);
+`endif	 
+     end
+   endtask
+
+   function [31:0] LabelRef;
+      input integer L;
+      begin
+`ifdef BENCH
+	if(L[0] === 1'bx) begin
+	   $display("Reference to uninitialized label");
+	   ASMerror = 1;
+	end
+`endif	 
+	 LabelRef = L - memPC;
+      end
+   endfunction
+
+   task endASM;
+      begin
+`ifdef GET_ASM_LABELS
+	 $finish();
+`endif	 
+`ifdef BENCH  
+	 if(ASMerror) $finish();
+`endif
+      end
+   endtask
+   
+   
+/****************************************************************************/
+
+/*
+ * RISC-V ABI register names.
+ */    
+
+   localparam zero = x0;
+   localparam ra   = x1;
+   localparam sp   = x2;
+   localparam gp   = x3;
+   localparam tp   = x4;
+   localparam t0   = x5;
+   localparam t1   = x6;
+   localparam t2   = x7;
+   localparam fp   = x8;
+   localparam s0   = x8;
+   localparam s1   = x9;
+   localparam a0   = x10;
+   localparam a1   = x11;
+   localparam a2   = x12;
+   localparam a3   = x13;
+   localparam a4   = x14;
+   localparam a5   = x15;
+   localparam a6   = x16;
+   localparam a7   = x17;
+   localparam s2   = x18;
+   localparam s3   = x19;
+   localparam s4   = x20;
+   localparam s5   = x21;
+   localparam s6   = x22;
+   localparam s7   = x23;
+   localparam s8   = x24;
+   localparam s9   = x25;
+   localparam s10  = x26;
+   localparam s11  = x27;
+   localparam t3   = x28;
+   localparam t4   = x29;
+   localparam t5   = x30;      
+   localparam t6   = x31;   
+
+/*
+ * RISC-V pseudo-instructions
+ */
+
+task NOP;
+   begin
+      ADD(x0,x0,x0);
+   end
+endtask
+
+// See https://stackoverflow.com/questions/50742420/
+// risc-v-build-32-bit-constants-with-lui-and-addi
+// Add imm[11] << 12 to the constant passed to LUI,
+// so that it cancels sign expansion done by ADDI
+// if imm[11] is 1.
+task LI;
+   input [4:0]  rd;
+   input [31:0] imm;
+   begin
+      if(imm == 0) begin
+	 ADD(rd,zero,zero);
+      end else if($signed(imm) >= -2048 && $signed(imm) < 2048) begin
+	 ADDI(rd,zero,imm);
+      end else begin
+	 LUI(rd,imm + (imm[11] << 12)); // cancel sign expansion
+	 if(imm[11:0] != 0) begin
+	    ADDI(rd,rd,imm[11:0]);
+	 end
+      end
+   end
+endtask
+
+task CALL;
+  input [31:0] offset;
+  begin
+     AUIPC(x6, offset);
+     JALR(x1, x6, offset[11:0]);
+  end
+endtask 
+
+task RET;
+  begin
+     JALR(x0,x1,0);
+  end
+endtask   
+
+task MV;
+   input [4:0]  rd;
+   input [4:0] 	rs1;
+   begin
+      ADD(rd,rs1,zero);
+   end
+endtask
+
+task J;
+   input [31:0] imm;
+   begin
+      // TODO: far targets
+      JAL(zero,imm);
+   end
+endtask
+
+task JR;
+   input [4:0]  rs1;
+   input [31:0] imm;   
+   begin
+      JALR(zero,rs1,imm);
+   end
+endtask
+   
+task BEQZ;
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      BEQ(rs1,x0,imm);
+   end
+endtask
+
+task BNEZ;
+   input [4:0]  rs1;
+   input [31:0] imm;
+   begin
+      BNE(rs1,x0,imm);
+   end
+endtask
+
+task BGT;
+   input [4:0]  rs1;
+   input [4:0]  rs2;   
+   input [31:0] imm;
+   begin
+      BLT(rs2,rs1,imm);
+   end
+endtask
+
+task DATAW;
+   input [31:0] w;
+   begin
+      MEM[memPC[31:2]] = w;
+      memPC = memPC+4;
+   end
+endtask
+
+task DATAB;
+   input [7:0] b1;
+   input [7:0] b2;
+   input [7:0] b3;
+   input [7:0] b4;   
+   begin
+      MEM[memPC[31:2]][ 7: 0] = b1;
+      MEM[memPC[31:2]][15: 8] = b2;
+      MEM[memPC[31:2]][23:16] = b3;
+      MEM[memPC[31:2]][31:24] = b4;            
+      memPC = memPC+4;
+   end
+endtask
+
+      
+   
+/****************************************************************************/ 
+   

--- a/examples/himbaechel/tangnano20k.cst
+++ b/examples/himbaechel/tangnano20k.cst
@@ -1,5 +1,4 @@
 IO_LOC "clk" 4;
-
 CLOCK_LOC "clk" BUFG;
 
 IO_LOC "led[0]" 15;
@@ -9,11 +8,18 @@ IO_LOC "led[3]" 18;
 IO_LOC "led[4]" 19;
 IO_LOC "led[5]" 20;
 
+IO_LOC "clk_i" 4;
+CLOCK_LOC "clk_i" BUFG;
+
 IO_LOC "key_i" 87;
 IO_PORT "key_i" IO_TYPE=LVCMOS33;
 IO_LOC "rst_i" 88;
 IO_PORT "rst_i" IO_TYPE=LVCMOS33;
 
+IO_LOC "TXD" 26;
+IO_PORT "TXD" PULL_MODE=UP;
+IO_LOC "RXD" 48;
+IO_PORT "RXD" PULL_MODE=UP;
 
 IO_LOC "LED_R" 15;
 IO_LOC "LED_G" 16;

--- a/examples/himbaechel/tangnano4k.cst
+++ b/examples/himbaechel/tangnano4k.cst
@@ -11,9 +11,17 @@ IO_LOC "rst_i" 14;
 IO_LOC "clk" 45;
 CLOCK_LOC "clk" BUFG;
 
+IO_LOC "clk_i" 45;
+CLOCK_LOC "clk_i" BUFG;
 
 IO_PORT "key_i" PULL_MODE=UP;
 IO_PORT "rst_i" PULL_MODE=UP;
+
+// UART
+IO_LOC "TXD" 44;
+IO_PORT "TXD" PULL_MODE=UP;
+IO_LOC "RXD" 46;
+IO_PORT "RXD" PULL_MODE=UP;
 
 // oser
 IO_LOC "oser_out" 35;

--- a/examples/himbaechel/tangnano9k.cst
+++ b/examples/himbaechel/tangnano9k.cst
@@ -10,9 +10,16 @@ IO_LOC "led[5]" 16;
 IO_LOC "key_i" 3;
 IO_LOC "rst_i" 4;
 
+IO_LOC "clk_i" 52;
+
 IO_LOC "LED_R" 10;
 IO_LOC "LED_G" 11;
 IO_LOC "LED_B" 13;
+
+IO_LOC "TXD" 32;
+IO_PORT "TXD" PULL_MODE=UP;
+IO_LOC "RXD" 31;
+IO_PORT "RXD" PULL_MODE=UP;
 
 // fake
 IO_LOC "led[6]" 35;


### PR DESCRIPTION
Examples of implementation of lessons 15, 16 and 18 from the Bruno Levy course are added
(https://github.com/BrunoLevy/learn-fpga/blob/master/FemtoRV/TUTORIALS/FROM_BLINKER_TO_RISCV/README.md).

These are parts devoted to the use of inferred BRAM for reading (15), for writing (16) and a complex example with the output of the Malderbrot set via UART (18).  Lessons are implemented for Tangnano4k, Tangnano9k and Tangnano20k boards.

The main function of these three examples is to serve as a canary in the mine, to detect regressions when making changes - like attosoc, but with the possibility of gradually simplifying the design - in particularly difficult cases, you can move along the original lessons from the 15th down to the 1st.

Since no new primitives are used there, there is no point in including them in the unpacking.

It might be worth implementing them for other boards where there are enough LUTs for this riscv.

Also a minor change so that new versions of Python do not swear at regular expressions.

Another purpose of including a small riscv is that it is useful for demonstrating the operation of DSP primitives via UART - when working with 18-bit numbers, the LEDs are no longer enough very quickly.