### PR TITLE
Add Functions for Concise Tile Parsing

### DIFF
--- a/apycula/fuse_h4x.py
+++ b/apycula/fuse_h4x.py
@@ -217,6 +217,67 @@ def parse_tile(d, ttyp, tile):
 
     return res
 
+def parse_tile_exact(d, ttyp, tile, fuse_loc=True):
+    w = d[ttyp]['width']
+    h = d[ttyp]['height']
+    res = {}
+    for start, table in [(2, 'shortval'), (2, 'wire'), (16, 'longval'),
+                         (1, 'longfuse'), (0, 'const')]:
+        if table in d[ttyp]: # skip missing entries
+            for subtyp, tablerows in d[ttyp][table].items():
+                pos_items, neg_items = {}, {}
+                active_rows = []
+                for row in tablerows:
+                    if row[0] > 0:
+                        row_fuses  = [fuse for fuse in row[start:] if fuse >= 0]
+                        locs = [fuse_lookup(d,ttyp, fuse) for fuse in row_fuses]
+                        test = [tile[loc[0]][loc[1]] == 1 for loc in locs]
+                        if all(test):
+                            full_row = row[:start]
+                            full_row.extend(row_fuses)
+                            active_rows.append(full_row)
+
+                # report fuse locations
+                if (active_rows):
+                    exact_cover = exact_table_cover(active_rows, start, table)
+                    if fuse_loc:
+                        for cover_row in exact_cover:
+                            cover_row[start:] = [fuse_lookup(d, ttyp, fuse) for fuse in cover_row[start:]]
+
+                    res.setdefault(table, {})[subtyp] = exact_cover
+    return res
+
+
+def exact_table_cover(t_rows, start, table=None):
+    try:
+        import xcover
+    except:
+        raise ModuleNotFoundError ("The xcover package needs to be installed to use the exact_cover function.\
+                                    \nYou may install it via pip: `pip install xcover`")
+
+    row_fuses = [set ([fuse for fuse in row[start:] if fuse!=-1]) for row in t_rows]
+    primary = set()
+    for row in row_fuses:
+        primary.update(row)
+    secondary = set()
+
+    # Enforce that every destination node has a single source
+    if table == 'wire':
+        for id, row in enumerate(t_rows):
+            # Casting the wire_id to a string ensures that it doesn't conflict with fuse_ids 
+            row_fuses[id].add(str(row[1]))
+            secondary.add(str(row[1]))
+        
+    g = xcover.covers(row_fuses, primary=primary, secondary=secondary, colored=False)
+    if g:
+        for r in g:
+            #g is an iterator, so this is just a hack to return the first solution.
+            #A future commit might introduce a heuristic for determining what solution is most plausible
+            #where there are multiple solutions
+            return [t_rows[idx] for idx in r]
+    else:
+        return []
+
 def scan_fuses(d, ttyp, tile):
     w = d[ttyp]['width']
     h = d[ttyp]['height']


### PR DESCRIPTION
This pull request adds two functions (`parse_tile_exact` and `exact_table_cover`) to `fuse_h4x.py`. The `parse_tile_exact` reports an exact cover over the rows in a table, computed using the `exact_table_cover`  function that are 'active' in a bitstream.

These functions come from the realization that the problem of determining what rows in a table were actually used can be conceptualized as an exact cover problem, assuming that no two active rows ever share fuses. So far, this assumption seems to hold up.  

These functions are quite effective at cutting out 'noise'. Consider the following comparison between the output of parse_tile and parse_tile_exact for the same tile. 

`parse_tile`
```
         [2, 10, (0, 35)]
	 [3, 10, (0, 35), (0, 34)]
	 [8, 10, (0, 34)]
	 [81, 3, (0, 48), (0, 45)]
	 [82, 3, (0, 47), (0, 45)]
	 [93, 3, (0, 48), (0, 36)]
	 [94, 3, (0, 47), (0, 36)]
	 [121, 3, (0, 48), (0, 45), (0, 47), (0, 36)]
	 [122, 3, (0, 48), (0, 45), (0, 36)]
	 [172, 3, (0, 45), (0, 47), (0, 36)]
	 [278, 3, (0, 48), (0, 45), (0, 47), (0, 36)]
```
`parse_tile_exact` 
```
         [3, 10, (0, 34), (0, 35)]
	 [278, 3, (0, 36), (0, 45), (0, 47), (0, 48)]
```

The `xcover` package (github.com/john/xcover) makes all this possible. However,  as it depends on numba and numpy, the import to xcover is 'hidden' within the `exact_table_cover` function. The reasoning here is that since these functions are really only useful to developers, the developer can bear the responsibility of making the xcover package available. If the xcover package is not installed,  a call to  `exact_table_cover` raises a ModuleNotFoundError exception, with a message on how the xcover package may be installed.
