### PR TITLE
update yosys CI branches

### DIFF
--- a/.github/workflows/chipdb.yml
+++ b/.github/workflows/chipdb.yml
@@ -271,7 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        yosys: [master, yosys-0.37]
+        yosys: [main, yosys-0.39]
         nextpnr: [master, nextpnr-0.7]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
It seems like Yosys renamed their main branch, breaking our CI

https://github.com/YosysHQ/yosys/pull/4297