### PR TITLE
Add PLL pads.

### DIFF
--- a/apycula/pindef.py
+++ b/apycula/pindef.py
@@ -96,6 +96,11 @@ def get_clock_locs(device, package):
     return [(pin['NAME'], *pin['CFG'].split('/')) for pin in df
             if 'CFG' in pin.keys() and pin['CFG'].startswith("GCLK")]
 
+def get_pll_pads_locs(device, package):
+    df = get_package(device, package, True)
+    return [(pin['NAME'], *pin['CFG'].split('/')) for pin in df
+            if 'CFG' in pin.keys() and 'PLL' in pin['CFG']]
+
 # { name : (is_diff, is_true_lvds, is_positive)}
 def get_diff_cap_info(device, package, special_pins=False):
     df = get_package(device, package, special_pins)

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -208,7 +208,7 @@ def fse_iob(fse, db, pin_locations, diff_cap_info, locations):
             bel.is_diff = is_diff
             bel.is_true_lvds = is_true_lvds
             bel.is_diff_p = is_positive
-            print(f"type:{ttyp} [{row}][{col}], IOB{bel_name[-1]}, diff:{is_diff}, true lvds:{is_true_lvds}, p:{is_positive}")
+            #print(f"type:{ttyp} [{row}][{col}], IOB{bel_name[-1]}, diff:{is_diff}, true lvds:{is_true_lvds}, p:{is_positive}")
     for ttyp, bels in iob_bels.items():
         for row, col in locations[ttyp]:
             db.grid[row][col].bels.update(iob_bels[ttyp])
@@ -261,6 +261,9 @@ if __name__ == "__main__":
     # IOB
     diff_cap_info = pindef.get_diff_cap_info(device, params['package'], True)
     fse_iob(fse, db, pin_locations, diff_cap_info, locations);
+
+    pad_locs = pindef.get_pll_pads_locs(device, params['package'])
+    chipdb.pll_pads(db, device, pad_locs)
 
     chipdb.dat_portmap(dat, db, device)
 

--- a/examples/himbaechel/Makefile.himbaechel
+++ b/examples/himbaechel/Makefile.himbaechel
@@ -291,7 +291,7 @@ bsram-%-tangnano1k-synth.json: pll/GW1NZ-1-dyn.vh %-image-rom.v %-video-ram.v %.
 %-tangnano4k-synth.json: %.v
 	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSCZ -D INV_BTN=0 -D FORCE_BRAM -D CPU_FREQ=27 -D BAUD_RATE=115200 -p "read_verilog $^; synth_gowin -json $@"
 
-blinky-pll-tangnano4k-synth.json: pll/GW1NS-4-dyn.vh blinky-pll-vr.v
+%-pll-tangnano4k-synth.json: pll/GW1NS-4-dyn.vh %-pll-vr.v
 	$(YOSYS) -D INV_BTN=0 -D LEDS_NR=6 -p "read_verilog $^; synth_gowin -json $@"
 	
 # ============================================================

--- a/examples/himbaechel/dual-pll-vr.v
+++ b/examples/himbaechel/dual-pll-vr.v
@@ -1,0 +1,57 @@
+`default_nettype none
+`include "pll/pllvr.v"
+// Two PLLs, one dynamic - frequencies are switched by pressing key2
+//                           / press key2
+// led[0] - pin 34 - 58.5MHz / 90MHz 
+// led[1] - pin 35 - LOCK PLL_0
+// led[2] - pin 29 - 464KHz  / 714KHz
+//
+// led[3] - pin 30 - 90MHz
+// led[4] - pin 31 - LOCK PLL_1
+// led[5] - pin 32 - 714KHz
+module top(input wire clk, output wire [5:0]led, input wire key_i);
+	wire gnd;
+	assign gnd = 1'b0;
+	wire dummy;
+	reg [5:0] fdiv;
+	reg [5:0] idiv;
+	reg [5:0] odiv;
+    Gowin_PLLVR rpll_0(
+        .clkout(led[0]),
+        .clkin(clk),
+		.lock_o(led[1]),
+		.reset(gnd),
+		.reset_p(gnd),
+		.clkfb(gnd),
+		.clkoutd_o(led[2]),
+		.fdiv(fdiv),
+		.idiv(idiv),
+		.odiv(6'b111100) // 8
+        );
+
+    Gowin_PLLVR rpll_1(
+        .clkout(led[3]),
+        .clkin(clk),
+		.lock_o(led[4]),
+		.reset(gnd),
+		.reset_p(gnd),
+		.clkfb(gnd),
+		.clkoutd_o(led[5]),
+		.fdiv(~6'd9),
+		.idiv(~6'd2),
+		.odiv(6'b111100) // 8
+        );
+
+	// dynamic
+	always @ (posedge clk) begin
+		if (key_i) begin
+			fdiv <= ~6'd12;
+			idiv <= ~6'd5;
+			odiv <= 6'b111000; // 16
+		end else begin
+			fdiv <= ~6'd9;
+			idiv <= ~6'd2;
+			odiv <= ~6'b111100; // 8
+		end
+	end
+endmodule


### PR DESCRIPTION
Whenever possible, we arrange the PLL so as to use a direct connection of pins to the inputs of the primitive. The main work happens in nextpnr-himbaechel, here we only prepare data about which pin corresponds to which PLL.

Also added an example for Tangnano4k where two PLLs compete for one input pin. Only one of them can win, but both must function.