### PR TITLE
BSRAM. Corrective action.

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -119,6 +119,8 @@ class Device:
     # - disabled blocks
     # - BUF(G)
     extra_func: Dict[Tuple[int, int], Dict[str, Any]] = field(default_factory=dict)
+    # Chip features currently related to block memory like "HAS_SP32", "NEED_SP_FIX", etc
+    chip_flags: List[str] = field(default_factory=list)
 
     @property
     def rows(self):
@@ -1647,6 +1649,14 @@ def sync_extra_func(dev):
         row, col = loc
         dev.extra_func.setdefault((row, col), {})['hclk_pips'] = pips
 
+def set_chip_flags(dev, device):
+    if device not in {"GW1NS-4", "GW1N-9"}:
+        dev.chip_flags.append("HAS_SP32")
+    if device in {'GW1N-1', 'GW1N-4', 'GW1NS-2', 'GW1N-9', 'GW2A-18'}:
+        dev.chip_flags.append("NEED_SP_FIX")
+    if device in {'GW1N-9C', 'GW2A-18C'}:
+        dev.chip_flags.append("NEED_BSRAM_OUTREG_FIX")
+
 def from_fse(device, fse, dat: Datfile):
     dev = Device()
     fse_create_simplio_rows(dev, dat)
@@ -1702,6 +1712,7 @@ def from_fse(device, fse, dat: Datfile):
     fse_create_logic2clk(dev, device, dat)
     disable_plls(dev, device)
     sync_extra_func(dev)
+    set_chip_flags(dev, device);
     return dev
 
 # get fuses for attr/val set using short/longval table

--- a/examples/himbaechel/Makefile.himbaechel
+++ b/examples/himbaechel/Makefile.himbaechel
@@ -321,6 +321,23 @@ bsram-%-tangnano9k-synth.json: pll/GW1N-9C-dyn.vh %-image-rom.v %-video-ram.v %.
 	$(YOSYS) -D INV_BTN=0 -p "read_verilog $^; synth_gowin -json $@"
 
 # ============================================================
+# szfpga miniboard (GW1N-9)
+%-miniszfpga.fs: %-miniszfpga.json
+	gowin_pack -d GW1N-9 -o $@ $<
+ 
+%-miniszfpga.json: %-miniszfpga-synth.json miniszfpga.cst
+	$(NEXTPNR) --json $< --write $@ --device GW1N-LV9QN48C6/I5 --vopt family=GW1N-9 --vopt cst=miniszfpga.cst
+
+%-miniszfpga-synth.json: %.v
+	$(YOSYS) -D LEDS_NR=4 -D OSC_TYPE_OSC -D INV_BTN=0 -D CPU_FREQ=50 -D BAUD_RATE=115200 -p "read_verilog $^; synth_gowin -json $@"
+
+blinky-pll-miniszfpga-synth.json: pll/GW1N-9-dyn.vh blinky-pll.v
+	$(YOSYS) -D INV_BTN=0 -D LEDS_NR=4 -p "read_verilog $^; synth_gowin -json $@"
+
+bsram-%-miniszfpga-synth.json: pll/GW1N-9-dyn.vh %-image-rom.v %-video-ram.v %.v
+	$(YOSYS) -D INV_BTN=0 -p "read_verilog $^; synth_gowin -json $@"
+
+# ============================================================
 # szfpga (GW1N-9)
 %-szfpga.fs: %-szfpga.json
 	gowin_pack -d GW1N-9 -o $@ $<

--- a/examples/himbaechel/femto-riscv-15.v
+++ b/examples/himbaechel/femto-riscv-15.v
@@ -44,7 +44,7 @@ module Memory (
 
    reg [31:0] MEM [0:255]; 
 
-   localparam slow_bit=20;
+   localparam slow_bit=22;
    
 `include "riscv_assembly.v"
    integer L0_   = 8;

--- a/examples/himbaechel/femto-riscv-18.v
+++ b/examples/himbaechel/femto-riscv-18.v
@@ -559,6 +559,7 @@ module top (
    
    corescore_emitter_uart #(
       .clk_freq_hz(`CPU_FREQ*1000000),
+      //.clk_freq_hz(27*1000000),
       .baud_rate(`BAUD_RATE)			    
    ) UART(
       .i_clk(clk),

--- a/examples/himbaechel/miniszfpga.cst
+++ b/examples/himbaechel/miniszfpga.cst
@@ -1,0 +1,77 @@
+//File Title: Physical Constraints file
+//Part Number: GW1N-LV9QN48C6/I5
+
+IO_LOC "clk" 35;
+IO_LOC "clk_i" 35;
+
+CLOCK_LOC "clk" BUFG;
+
+IO_LOC "rst_i" 28;	// key0
+IO_LOC "key_i" 28;
+
+IO_LOC "led[0]" 38;
+IO_LOC "led[1]" 39;
+IO_LOC "led[2]" 40;
+IO_LOC "led[3]" 41;
+
+// fake
+IO_LOC "led[4]" 42;
+IO_LOC "led[5]" 43;
+IO_LOC "led[6]" 44;
+IO_LOC "led[7]" 45;
+
+IO_LOC "TXD" 23;
+IO_PORT "TXD" PULL_MODE=UP;
+IO_LOC "RXD" 24;
+IO_PORT "RXD" PULL_MODE=UP;
+
+// oser
+IO_LOC "oser_out" 29;
+IO_LOC "io16"     29;
+IO_LOC "pclk_o"   51;
+IO_LOC "fclk_o"   50;
+
+// ides
+IO_LOC "fclk_i" 43;
+IO_LOC "data_i" 46;
+IO_LOC "q_o[0]" 121;
+IO_LOC "q_o[1]" 42;
+IO_LOC "q_o[2]" 125;
+IO_LOC "q_o[3]" 48;
+IO_LOC "q_o[4]" 49;
+IO_LOC "q_o[5]" 117;
+IO_LOC "q_o[6]" 115;
+IO_LOC "q_o[7]" 113;
+
+// emulated lvds pins
+IO_LOC "elvds_p" 44;
+IO_LOC "elvds_n" 45;
+
+// true LVDS pins
+IO_LOC "tlvds_p" 42;
+IO_LOC "tlvds_n" 43;
+
+// RGB LCD
+IO_LOC "LCD_CLK"  110;
+IO_LOC "LCD_DEN"  111;
+IO_LOC "LCD_HYNC" 112;
+IO_LOC "LCD_SYNC" 113;
+IO_LOC "LCD_B[4]" 114;
+IO_LOC "LCD_B[3]" 115;
+IO_LOC "LCD_B[2]" 116;
+IO_LOC "LCD_B[1]" 117;
+IO_LOC "LCD_B[0]" 118;
+IO_LOC "LCD_G[5]" 119;
+IO_LOC "LCD_G[4]" 120;
+IO_LOC "LCD_G[3]" 121;
+IO_LOC "LCD_G[2]" 122;
+IO_LOC "LCD_G[1]" 123;
+IO_LOC "LCD_G[0]" 124;
+IO_LOC "LCD_R[4]" 125;
+IO_LOC "LCD_R[3]" 126;
+IO_LOC "LCD_R[2]" 128;
+IO_LOC "LCD_R[1]" 129;
+IO_LOC "LCD_R[0]" 130;
+
+IO_LOC "LCD_XR"   131;
+IO_LOC "LCD_XL"   132;


### PR DESCRIPTION
Chips that have features in the implementation of BSRAM are marked with special flags, to which nextpnr reacts by adding corrective primitives such as LUTs and DFFs and changing routing if necessary.

Currently this is a fix for WRE-CE signals in Single Port BSRAM and a fix for READ_MODE=1'b1 (pipeline).

A .CST file is also added for the reduced SZFPGA board - it uses a GW1N-9 chip in a 48-pin package versus a “full-fledged” SZFPGA with a GW1NR-9 chip in a 144-pin package.