### PR TITLE
Use builtin USB-serial

### DIFF
--- a/examples/himbaechel/tangnano9k.cst
+++ b/examples/himbaechel/tangnano9k.cst
@@ -16,9 +16,10 @@ IO_LOC "LED_R" 10;
 IO_LOC "LED_G" 11;
 IO_LOC "LED_B" 13;
 
-IO_LOC "TXD" 32;
+// Use buildin USB-serial
+IO_LOC "TXD" 17;
 IO_PORT "TXD" PULL_MODE=UP;
-IO_LOC "RXD" 31;
+IO_LOC "RXD" 18;
 IO_PORT "RXD" PULL_MODE=UP;
 
 // fake


### PR DESCRIPTION
Pins 17 and 18 on the Tangnano9k board can be used as UART over USB to communicate with a big computer. It allows to use the same cable used for programming, without additional devices.