### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -65,7 +65,7 @@ def sanitize_name(name):
         retname = name[:-4]
     if _verilog_name.fullmatch(retname):
         return retname
-    return f"\{retname} "
+    return fr"\{retname} "
 
 def extra_pll_bels(cell, row, col, num, cellname):
     # rPLL can occupy several cells, add them depending on the chip


### PR DESCRIPTION
This commit remove an invalid escape sequence.

Error originally reported here [0] 

[0] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085325

