### PR TITLE
add missing examples to makefile

### DIFF
--- a/examples/himbaechel/Makefile.himbaechel
+++ b/examples/himbaechel/Makefile.himbaechel
@@ -59,7 +59,7 @@ all: \
 	ides4-tangnano4k.fs ivideo-tangnano4k.fs ides8-tangnano4k.fs ides10-tangnano4k.fs \
 	oser10-tlvds-tangnano4k.fs \
 	femto-riscv-15-tangnano4k.fs femto-riscv-16-tangnano4k.fs femto-riscv-18-tangnano4k.fs \
-	dsp-mult36x36-tangnano4k.fs dsp-padd9-tangnano4k.fs dsp-padd18-tangnano4k.fs \
+	dsp-mult18x18-tangnano4k.fs dsp-mult36x36-tangnano4k.fs dsp-padd9-tangnano4k.fs dsp-padd18-tangnano4k.fs \
 	dsp-mult9x9-tangnano4k.fs dsp-alu54d-tangnano4k.fs dsp-multalu18x18-tangnano4k.fs \
 	dsp-multalu36x18-tangnano4k.fs dsp-multaddalu18x18-tangnano4k.fs \
 	dqce-tangnano4k.fs dcs-tangnano4k.fs emcu-blinky-tangnano4k.fs emcu-with-apb-blinky-tangnano4k.fs \

--- a/examples/himbaechel/Makefile.himbaechel
+++ b/examples/himbaechel/Makefile.himbaechel
@@ -9,6 +9,7 @@ all: \
 	blinky-clkdiv-tangnano20k.fs dvi-example-tangnano20k.fs blinky-clkdiv-dhcen-tangnano20k.fs \
 	oddr-elvds-tangnano20k.fs pll-nanolcd-tangnano20k.fs attosoc-tangnano20k.fs \
 	oser4-tangnano20k.fs ovideo-tangnano20k.fs oser8-tangnano20k.fs oser10-tangnano20k.fs \
+	iddr-tangnano20k.fs iddrc-tangnano20k.fs \
 	ides4-tangnano20k.fs ivideo-tangnano20k.fs ides8-tangnano20k.fs ides10-tangnano20k.fs \
 	bsram-pROM-tangnano20k.fs bsram-SDPB-tangnano20k.fs bsram-SP-tangnano20k.fs \
 	bsram-DPB-tangnano20k.fs bsram-pROMX9-tangnano20k.fs bsram-SDPX9B-tangnano20k.fs \
@@ -24,6 +25,7 @@ all: \
 	blinky-clkdiv-primer20k.fs dvi-example-primer20k.fs blinky-clkdiv-dhcen-primer20k.fs \
 	oddr-elvds-primer20k.fs pll-nanolcd-primer20k.fs attosoc-primer20k.fs \
 	oser4-primer20k.fs ovideo-primer20k.fs oser8-primer20k.fs oser10-primer20k.fs \
+	iddr-primer20k.fs iddrc-primer20k.fs \
 	ides4-primer20k.fs ivideo-primer20k.fs ides8-primer20k.fs ides10-primer20k.fs \
 	bsram-pROM-primer20k.fs bsram-SDPB-primer20k.fs bsram-SP-primer20k.fs \
 	bsram-DPB-primer20k.fs bsram-pROMX9-primer20k.fs bsram-SDPX9B-primer20k.fs \
@@ -37,6 +39,7 @@ all: \
 	blinky-tangnano.fs shift-tangnano.fs blinky-tbuf-tangnano.fs blinky-oddr-tangnano.fs \
 	blinky-osc-tangnano.fs elvds-tangnano.fs oddr-elvds-tangnano.fs pll-nanolcd-tangnano.fs \
 	oser4-tangnano.fs ovideo-tangnano.fs oser8-tangnano.fs oser10-tangnano.fs \
+	iddr-tangnano.fs iddrc-tangnano.fs \
 	ides4-tangnano.fs ivideo-tangnano.fs ides8-tangnano.fs ides10-tangnano.fs \
 	bsram-pROM-tangnano.fs bsram-SDPB-tangnano.fs bsram-DPB-tangnano.fs \
 	bsram-SP-tangnano.fs bsram-pROMX9-tangnano.fs bsram-SDPX9B-tangnano.fs \
@@ -45,6 +48,7 @@ all: \
 	blinky-tangnano1k.fs shift-tangnano1k.fs blinky-tbuf-tangnano1k.fs blinky-oddr-tangnano1k.fs \
 	blinky-osc-tangnano1k.fs elvds-tangnano1k.fs oddr-elvds-tangnano1k.fs pll-nanolcd-tangnano1k.fs \
 	oser4-tangnano1k.fs ovideo-tangnano1k.fs oser8-tangnano1k.fs oser10-tangnano1k.fs \
+	iddr-tangnano1k.fs iddrc-tangnano1k.fs \
 	ides4-tangnano1k.fs ivideo-tangnano1k.fs ides8-tangnano1k.fs ides10-tangnano1k.fs \
 	bsram-pROM-tangnano1k.fs bsram-SDPB-tangnano1k.fs bsram-DPB16-tangnano1k.fs \
 	bsram-SP-tangnano1k.fs bsram-pROMX9-tangnano1k.fs bsram-SDPX9B-tangnano1k.fs \
@@ -55,7 +59,7 @@ all: \
 	blinky-osc-tangnano4k.fs tlvds-tangnano4k.fs elvds-tangnano4k.fs oddr-tlvds-tangnano4k.fs \
 	oddr-elvds-tangnano4k.fs blinky-pll-tangnano4k.fs oser16-tangnano4k.fs \
 	oser4-tangnano4k.fs ovideo-tangnano4k.fs oser8-tangnano4k.fs oser10-tangnano4k.fs \
-	ides16-tangnano4k.fs \
+	iddr-tangnano4k.fs iddrc-tangnano4k.fs ides16-tangnano4k.fs \
 	ides4-tangnano4k.fs ivideo-tangnano4k.fs ides8-tangnano4k.fs ides10-tangnano4k.fs \
 	oser10-tlvds-tangnano4k.fs \
 	femto-riscv-15-tangnano4k.fs femto-riscv-16-tangnano4k.fs femto-riscv-18-tangnano4k.fs \
@@ -70,6 +74,7 @@ all: \
 	blinky-osc-tangnano9k.fs tlvds-tangnano9k.fs elvds-tangnano9k.fs oddr-tlvds-tangnano9k.fs \
 	oddr-elvds-tangnano9k.fs pll-nanolcd-tangnano9k.fs oser16-tangnano9k.fs attosoc-tangnano9k.fs \
 	oser4-tangnano9k.fs ovideo-tangnano9k.fs oser8-tangnano9k.fs oser10-tangnano9k.fs \
+	iddr-tangnano9k.fs iddrc-tangnano9k.fs \
 	ides4-tangnano9k.fs ivideo-tangnano9k.fs ides8-tangnano9k.fs ides10-tangnano9k.fs \
 	bsram-pROM-tangnano9k.fs bsram-SDPB-tangnano9k.fs bsram-SP-tangnano9k.fs \
 	bsram-DPB-tangnano9k.fs bsram-pROMX9-tangnano9k.fs bsram-SDPX9B-tangnano9k.fs \
@@ -85,7 +90,7 @@ all: \
 	blinky-osc-szfpga.fs tlvds-szfpga.fs elvds-szfpga.fs oddr-tlvds-szfpga.fs \
 	oddr-elvds-szfpga.fs blinky-pll-szfpga.fs oser16-szfpga.fs attosoc-szfpga.fs \
 	oser4-szfpga.fs ovideo-szfpga.fs oser8-szfpga.fs oser10-szfpga.fs \
-	ides16-szfpga.fs \
+	iddr-szfpga.fs iddrc-szfpga.fs ides16-szfpga.fs \
 	ides4-szfpga.fs ivideo-szfpga.fs ides8-szfpga.fs ides10-szfpga.fs \
 	bsram-pROM-szfpga.fs bsram-SDPB-szfpga.fs bsram-SP-szfpga.fs \
 	bsram-pROMX9-szfpga.fs bsram-SDPX9B-szfpga.fs \
@@ -99,7 +104,7 @@ all: \
 	blinky-osc-tec0117.fs tlvds-tec0117.fs elvds-tec0117.fs oddr-tlvds-tec0117.fs \
 	oddr-elvds-tec0117.fs blinky-pll-tec0117.fs oser16-tec0117.fs attosoc-tec0117.fs \
 	oser4-tec0117.fs ovideo-tec0117.fs oser8-tec0117.fs oser10-tec0117.fs \
-	ides16-tec0117.fs \
+	iddr-tec0117.fs iddrc-tec0117.fs ides16-tec0117.fs \
 	ides4-tec0117.fs ivideo-tec0117.fs ides8-tec0117.fs ides10-tec0117.fs \
 	dsp-mult18x18-tec0117.fs dsp-mult36x36-tec0117.fs dsp-padd9-tec0117.fs dsp-padd18-tec0117.fs \
 	dsp-mult9x9-tec0117.fs dsp-alu54d-tec0117.fs dsp-multalu18x18-tec0117.fs \
@@ -109,6 +114,7 @@ all: \
 	blinky-osc-runber.fs tlvds-runber.fs elvds-runber.fs oddr-tlvds-runber.fs \
 	oddr-elvds-runber.fs blinky-pll-runber.fs \
 	oser4-runber.fs ovideo-runber.fs oser8-runber.fs oser10-runber.fs \
+	iddr-runber.fs iddrc-runber.fs \
 	ides4-runber.fs ivideo-runber.fs ides8-runber.fs ides10-runber.fs \
 	dsp-mult36x36-runber.fs dsp-padd9-runber.fs dsp-padd18-runber.fs \
 	dsp-mult9x9-runber.fs dsp-alu54d-runber.fs dsp-multalu18x18-runber.fs \

--- a/examples/himbaechel/Makefile.himbaechel
+++ b/examples/himbaechel/Makefile.himbaechel
@@ -14,7 +14,7 @@ all: \
 	bsram-DPB-tangnano20k.fs bsram-pROMX9-tangnano20k.fs bsram-SDPX9B-tangnano20k.fs \
 	bsram-SPX9-tangnano20k.fs bsram-DPX9B-tangnano20k.fs \
 	femto-riscv-15-tangnano20k.fs femto-riscv-16-tangnano20k.fs femto-riscv-18-tangnano20k.fs \
-	dsp-mult36x36-tangnano20k.fs dsp-padd9-tangnano20k.fs dsp-padd18-tangnano20k.fs \
+	dsp-mult18x18-tangnano20k.fs dsp-mult36x36-tangnano20k.fs dsp-padd9-tangnano20k.fs dsp-padd18-tangnano20k.fs \
 	dsp-mult9x9-tangnano20k.fs dsp-alu54d-tangnano20k.fs dsp-multalu18x18-tangnano20k.fs \
 	dsp-multalu36x18-tangnano20k.fs dsp-multaddalu18x18-tangnano20k.fs \
 	dqce-tangnano20k.fs  dcs-tangnano20k.fs \
@@ -29,7 +29,7 @@ all: \
 	bsram-DPB-primer20k.fs bsram-pROMX9-primer20k.fs bsram-SDPX9B-primer20k.fs \
 	bsram-SPX9-primer20k.fs bsram-DPX9B-primer20k.fs \
 	femto-riscv-15-primer20k.fs femto-riscv-16-primer20k.fs femto-riscv-18-primer20k.fs \
-	dsp-mult36x36-primer20k.fs dsp-padd9-primer20k.fs dsp-padd18-primer20k.fs \
+	dsp-mult18x18-primer20k.fs dsp-mult36x36-primer20k.fs dsp-padd9-primer20k.fs dsp-padd18-primer20k.fs \
 	dsp-mult9x9-primer20k.fs dsp-alu54d-primer20k.fs dsp-multalu18x18-primer20k.fs \
 	dsp-multalu36x18-primer20k.fs dsp-multaddalu18x18-primer20k.fs \
 	dqce-primer20k.fs  dcs-primer20k.fs \
@@ -49,7 +49,7 @@ all: \
 	bsram-pROM-tangnano1k.fs bsram-SDPB-tangnano1k.fs bsram-DPB16-tangnano1k.fs \
 	bsram-SP-tangnano1k.fs bsram-pROMX9-tangnano1k.fs bsram-SDPX9B-tangnano1k.fs \
 	bsram-SPX9-tangnano1k.fs bsram-DPX9B18-tangnano1k.fs \
-	dqce-tangnano1k.fs dcs-tangnano1k.fs userflash-tangnano1k.fs \
+	dqce-tangnano1k.fs dcs-tangnano1k.fs userflash-tangnano1k.fs bandgap-tangnano1k.fs \
 	\
 	blinky-tangnano4k.fs shift-tangnano4k.fs blinky-tbuf-tangnano4k.fs blinky-oddr-tangnano4k.fs \
 	blinky-osc-tangnano4k.fs tlvds-tangnano4k.fs elvds-tangnano4k.fs oddr-tlvds-tangnano4k.fs \
@@ -76,7 +76,7 @@ all: \
 	bsram-SPX9-tangnano9k.fs bsram-DPX9B-tangnano9k.fs \
 	oser10-elvds-tangnano9k.fs \
 	femto-riscv-15-tangnano9k.fs femto-riscv-16-tangnano9k.fs femto-riscv-18-tangnano9k.fs \
-	dsp-mult36x36-tangnano9k.fs dsp-padd9-tangnano9k.fs dsp-padd18-tangnano9k.fs \
+	dsp-mult18x18-tangnano9k.fs dsp-mult36x36-tangnano9k.fs dsp-padd9-tangnano9k.fs dsp-padd18-tangnano9k.fs \
 	dsp-mult9x9-tangnano9k.fs dsp-alu54d-tangnano9k.fs dsp-multalu18x18-tangnano9k.fs \
 	dsp-multalu36x18-tangnano9k.fs dsp-multaddalu18x18-tangnano9k.fs \
 	dqce-tangnano9k.fs dcs-tangnano9k.fs femto-riscv-userflash-tangnano9k.fs \
@@ -91,7 +91,7 @@ all: \
 	bsram-pROMX9-szfpga.fs bsram-SDPX9B-szfpga.fs \
 	bsram-SPX9-szfpga.fs \
 	femto-riscv-15-szfpga.fs femto-riscv-16-szfpga.fs femto-riscv-18-szfpga.fs \
-	dsp-mult36x36-szfpga.fs dsp-padd9-szfpga.fs dsp-padd18-szfpga.fs \
+	dsp-mult18x18-szfpga.fs dsp-mult36x36-szfpga.fs dsp-padd9-szfpga.fs dsp-padd18-szfpga.fs \
 	dsp-mult9x9-szfpga.fs dsp-alu54d-szfpga.fs dsp-multalu18x18-szfpga.fs \
 	dsp-multalu36x18-szfpga.fs dsp-multaddalu18x18-szfpga.fs \
 	\
@@ -101,7 +101,7 @@ all: \
 	oser4-tec0117.fs ovideo-tec0117.fs oser8-tec0117.fs oser10-tec0117.fs \
 	ides16-tec0117.fs \
 	ides4-tec0117.fs ivideo-tec0117.fs ides8-tec0117.fs ides10-tec0117.fs \
-	dsp-mult36x36-tec0117.fs dsp-padd9-tec0117.fs dsp-padd18-tec0117.fs \
+	dsp-mult18x18-tec0117.fs dsp-mult36x36-tec0117.fs dsp-padd9-tec0117.fs dsp-padd18-tec0117.fs \
 	dsp-mult9x9-tec0117.fs dsp-alu54d-tec0117.fs dsp-multalu18x18-tec0117.fs \
 	dsp-multalu36x18-tec0117.fs dsp-multaddalu18x18-tec0117.fs \
 	\

--- a/examples/himbaechel/iddr.v
+++ b/examples/himbaechel/iddr.v
@@ -1,0 +1,28 @@
+`default_nettype none
+module top(input wire clk, 
+	input wire rst_i, 
+	input wire fclk_i,
+	input wire data_i,
+	output wire [7:0]q_o);
+
+	assign q_o[2] = !rst_i;
+    IDDR id(
+        .D(data_i),
+		.CLK(fclk_i),
+        .Q0(q_o[0]),
+        .Q1(q_o[1])
+    );
+	defparam id.Q0_INIT=1'b0;
+	defparam id.Q1_INIT=1'b0;
+
+	// dummy DFF
+	assign q_o[4] = dummy_r;
+	reg dummy_r;
+	always @(posedge fclk_i) begin
+		if (!rst_i) begin
+			dummy_r <= 0;
+		end else begin
+			dummy_r <= !dummy_r;
+		end
+	end
+endmodule

--- a/examples/himbaechel/iddrc.v
+++ b/examples/himbaechel/iddrc.v
@@ -1,0 +1,25 @@
+`default_nettype none
+module top(input wire clk, 
+	input wire rst_i, 
+	input wire fclk_i,
+	input wire data_i,
+	output wire [7:0]q_o);
+
+	assign q_o[2] = !rst_i;
+    IDDRC id(
+        .D(data_i),
+		.CLK(fclk_i),
+		.CLEAR(!rst_i),
+        .Q0(q_o[0]),
+        .Q1(q_o[1])
+    );
+	defparam id.Q0_INIT=1'b0;
+	defparam id.Q1_INIT=1'b0;
+
+	// dummy DFF
+	assign q_o[4] = dummy_r;
+	reg dummy_r;
+	always @(posedge fclk_i) begin
+		dummy_r <= !dummy_r;
+	end
+endmodule


### PR DESCRIPTION
I found out the bandgap and mul18 examples were not being built.

It seems like on GW1N-4 devices the example errors, not sure why.