### PR TITLE
Add IEM (Input Edge Monitor)

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -2632,6 +2632,9 @@ def dat_portmap(dat, dev, device):
                         elif nam == 'FCLK':
                             # dummy Input, we'll make a special pips for it
                             bel.portmap[nam] = "FCLK"
+                    # these inputs for IEM window selection
+                    bel.portmap['WINSIZE0'] = {'A':"C6", 'B':"C7"}[buf]
+                    bel.portmap['WINSIZE1'] = {'A':"D6", 'B':"D7"}[buf]
                     for idx, nam in _iologic_outputs:
                         w_idx = dat.portmap[f'Iologic{buf}Out'][idx]
                         if w_idx >= 0:

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -2076,6 +2076,7 @@ _iologic_default_attrs = {
         'DUMMY': {},
         'IOLOGIC': {},
         'IOLOGIC_DUMMY': {},
+        'IOLOGICI_EMPTY': {'GSREN': 'false', 'LSREN': 'true'},
         'ODDR': { 'TXCLK_POL': '0'},
         'ODDRC': { 'TXCLK_POL': '0'},
         'OSER4': { 'GSREN': 'false', 'LSREN': 'true', 'TXCLK_POL': '0', 'HWL': 'false'},
@@ -2140,7 +2141,9 @@ def set_iologic_attrs(db, attrs, param):
         # in_attrs['LSRMUX_LSR'] = 'INV'
 
     if 'INMODE' in attrs:
-        if param['IOLOGIC_TYPE'] not in {'IDDR', 'IDDRC'}:
+        if param['IOLOGIC_TYPE'] == 'IOLOGICI_EMPTY':
+            in_attrs.pop('INMODE', None);
+        elif param['IOLOGIC_TYPE'] not in {'IDDR', 'IDDRC'}:
             #in_attrs['CLKODDRMUX_WRCLK'] = 'ECLK0'
             in_attrs['CLKOMUX_1'] = '1'
             in_attrs['CLKODDRMUX_ECLK'] = 'UNKNOWN'
@@ -2324,13 +2327,14 @@ def place(db, tilemap, bels, cst, args):
             typ = 'IOB'
 
         if is_himbaechel and typ in {'IOLOGIC', 'IOLOGICI', 'IOLOGICO', 'IOLOGIC_DUMMY', 'ODDR', 'ODDRC', 'OSER4',
-                                     'OSER8', 'OSER10', 'OVIDEO', 'IDDR', 'IDDRC', 'IDES4', 'IDES8', 'IDES10', 'IVIDEO'}:
+                                     'OSER8', 'OSER10', 'OVIDEO', 'IDDR', 'IDDRC', 'IDES4', 'IDES8', 'IDES10', 'IVIDEO',
+                                     'IOLOGICI_EMPTY'}:
             if num[-1] in {'I', 'O'}:
                 num = num[:-1]
             if typ == 'IOLOGIC_DUMMY':
                 attrs['IOLOGIC_FCLK'] = pnr['modules']['top']['cells'][attrs['MAIN_CELL']]['attributes']['IOLOGIC_FCLK']
             attrs['IOLOGIC_TYPE'] = typ
-            if typ not in {'IDDR', 'IDDRC', 'ODDR', 'ODDRC'}:
+            if typ not in {'IDDR', 'IDDRC', 'ODDR', 'ODDRC', 'IOLOGICI_EMPTY'}:
                 # We clearly distinguish between the HCLK wires and clock
                 # spines at the nextpnr level by name, but in the fuse tables
                 # they have the same number, this is possible because the clock

--- a/examples/himbaechel/iddr.v
+++ b/examples/himbaechel/iddr.v
@@ -15,6 +15,15 @@ module top(input wire clk,
 	defparam id.Q0_INIT=1'b0;
 	defparam id.Q1_INIT=1'b0;
 
+	IEM iem0(
+		.D(data_i),
+		.CLK(fclk_i),
+		.MCLK(clk),
+		.LAG(q_o[5]),
+		.LEAD(q_o[6]),
+		.RESET(!rst_i)
+	);
+
 	// dummy DFF
 	assign q_o[4] = dummy_r;
 	reg dummy_r;

--- a/examples/himbaechel/ides4.v
+++ b/examples/himbaechel/ides4.v
@@ -21,6 +21,15 @@ module top(input wire clk,
 	defparam ides.GSREN="false";
 	defparam ides.LSREN="true";
 
+	IEM iem0(
+        .D(data_i),
+        .CLK(pclk_o),
+        .MCLK(clk),
+        .LAG(q_o[5]),
+        .LEAD(q_o[6]),
+        .RESET(!rst)
+    );		
+
     reg pclk_r;
     always @(posedge fclk_i) begin
         pclk_r <= !pclk_r;


### PR DESCRIPTION
This sensor will in the future allow dynamic control of the delay line at the IBUF input. At the moment, the changes to the examples only verify that the primitive compiles successfully.

This primitive is similar to MUXes in the sense that it has no fuses, it is always on and it is up to the user to use the signals on its outputs or not.