### PR TITLE
Fix PLL limits for GW2A-18 C8/I7

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -271,8 +271,8 @@ _permitted_freqs = {
         "GW1N-9":  (400, 500, 3.125,  1000, 400),
         "GW1N-9C": (400, 600, 3.125,  1200, 400),
         "GW1NS-2": (400, 500, 3.125,  1200, 400),
-        "GW2A-18": (400, 600, 3.125,  1200, 400), # XXX check it
-        "GW2A-18C": (400, 600, 3.125,  1200, 400), # XXX check it
+        "GW2A-18": (500, 625, 3.90625, 1250, 500),
+        "GW2A-18C": (500, 625, 3.90625, 1250, 500),
         }
 # input params are calculated as described in GOWIN doc (UG286-1.7E_Gowin Clock User Guide)
 # fref = fclkin / idiv

--- a/apycula/gowin_pll.py
+++ b/apycula/gowin_pll.py
@@ -1,7 +1,9 @@
 # pll tool to find best match for the target frequency
 # calculations based on: https://github.com/juj/gowin_fpga_code_generators/blob/main/pll_calculator.html
-# limits from: http://cdn.gowinsemi.com.cn/DS117E.pdf, http://cdn.gowinsemi.com.cn/DS861E.pdf
-#
+# limits from:
+# - http://cdn.gowinsemi.com.cn/DS117E.pdf,
+# - http://cdn.gowinsemi.com.cn/DS861E.pdf,
+# - https://cdn.gowinsemi.com.cn/DS226E.pdf
 
 import sys
 import re
@@ -218,11 +220,11 @@ def main():
             "comment": "untested",
             "pll_name": "rPLL",
             "pfd_min": 3,
-            "pfd_max": 400,
-            "vco_min": 400,
-            "vco_max": 1000,
-            "clkout_min": 3.125,
-            "clkout_max": 500,
+            "pfd_max": 500,
+            "vco_min": 500,
+            "vco_max": 1250,
+            "clkout_min": 3.90625,
+            "clkout_max": 625,
         },
     }
 


### PR DESCRIPTION
Hello,

This PR sets the PLL limits of GW2A-18 C8/I7 according to [DS226E](https://cdn.gowinsemi.com.cn/DS226E.pdf).