### PR TITLE
WIP: Add family footnote to 20k-boards

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,13 @@ Currently supported boards are
  * Sipeed Tang Nano 1K: GW1NZ-LV1QN48C6/I5
  * Sipeed Tang Nano 4K: GW1NSR-LV4CQN48PC7/I6
  * Sipeed Tang Nano 9K: GW1NR-LV9QN88PC6/I5 [^1]
- * Sipeed Tang Nano 20K: GW2AR-LV18QN88C8/I7
- * Sipeed Tang Primer 20K: GW2A-LV18PG256C8/I7
+ * Sipeed Tang Nano 20K: GW2AR-LV18QN88C8/I7 [^1]
+ * Sipeed Tang Primer 20K: GW2A-LV18PG256C8/I7 [^1]
  * Seeed RUNBER: GW1N-UV4LQ144C6/I5
  * @Disasm honeycomb: GW1NS-UX2CQN48C5/I4
  * szfpga: GW1NR-LV9LQ144PC6/I5
 
-[^1]: `C` devices require passing the `--family` flag as well as `--device` to Nextpnr, and stating the family in place of device when passing `-d` to `gowin_pack` because the C isn't part of the device ID but only present in the date code. Check `examples/Makefile` for the correct command.
+[^1]: `C` devices require passing the `--family` flag as well as `--device` to Nextpnr, and stating the family in place of device when passing `-d` to `gowin_pack` because the C isn't part of the device ID but only present in the date code. Check `examples/himbaechel/Makefile` for the correct command.
 
 Install the tools with pip.
 


### PR DESCRIPTION
The footnote mentions "`C`-devices" but I can't quite figure out what that means

Edit: Oh, I found `examples/himbaechel`. I'll repoint the footnote to that since it seems to be the big new thing

~~I also now realized that there is no example for this board so I attempted to create one. I'm a bit surprised to see `nextpnr-gowin` in the examples since I thought that was deprecated and replaced by himabechel. Since I don't have -gowin installed, I tried to at least create the example using -himbaechel for porting later.

However, with this `cst` file
```
IO_LOC "clk" 4;
IO_LOC "led[0]" 15;
IO_LOC "led[1]" 16;
IO_LOC "led[2]" 17;
IO_LOC "led[3]" 18;
IO_LOC "led[4]" 19;
IO_LOC "led[5]" 20;
```
I get
```
nextpnr-himbaechel --json blinky-tangnano20k-synth.json --write blinky-tangnano20k.json --device GW2AR-LV18QN88C8/I7 --vopt family=GW2A-18C --vopt cst:tangnano20k.cst
Info: Using uarch 'gowin' for device 'GW2AR-LV18QN88C8/I7'

Info: Create constant nets...
Info: Modify LUTs...
Info: Pack IOBs...
ERROR: Unconstrained IO:led_OBUF_O_5
```
not sure what is going wrong there...

Edit: Oh, I now found `examples/himbaechel` with a working 20k configuration~~