### PR TITLE
Implement FF in IO blocks.

### DIFF
--- a/examples/himbaechel/ioregs.v
+++ b/examples/himbaechel/ioregs.v
@@ -1,0 +1,30 @@
+module top (
+	input clk,
+	input key_i,
+	input rst_i,
+	output [`LEDS_NR-1:0] led
+);
+
+wire key = key_i ^ `INV_BTN;
+wire reset = rst_i ^ `INV_BTN;
+
+reg [25:0] ctr_q;
+wire [25:0] ctr_d;
+
+always @(posedge clk) begin
+	if (reset) begin
+		ctr_q <= ctr_d;
+	end
+end
+
+reg [`LEDS_NR - 2:0] led_r;
+assign led = {ctr_q[25:25], led_r};
+assign ctr_d = ctr_q + 1'b1;
+
+always @(posedge clk) begin
+	if (!key) begin
+		led_r <= ctr_q[25:25-(`LEDS_NR - 2)];
+	end
+end
+
+endmodule


### PR DESCRIPTION
There are three registers in IO blocks: IREG, OREG, and TREG. Not in all of them, but only where there is IOLOGIC because these registers are part of it.

Hence the first limitation: if FF is placed in an IO block, the rest of the IOLOGIC cannot be used.

The second limitation is related to the fact that all three registers have common wires CLK, ClockEnable and LocalSetReset and this dictates the types of flipflop's - let's say DFF (in Gowin's implementation) requires a constant connection CE to VCC, so you can not use in the same IO block DFFE, which CE is a signal.