### PR TITLE
Restore CUPCDN with a different bit pattern

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -368,8 +368,8 @@ def fse_luts(fse, ttyp):
             # CDN
             add_alu_mode(mode, bel.modes, lut, "7",     "0101000001011111")
             # CUPCDN
-            # The functionality of this seems to be the same with SUB
-            # add_alu_mode(mode, bel.modes, lut, "8",     "1010000001011010")
+            # We set bits 8 through 11 to make it distinct from SUB
+            add_alu_mode(mode, bel.modes, lut, "8",     "1010111101011010")
             # MULT   INIT="0111 1000 1000 1000"
             #
             add_alu_mode(mode, bel.modes, lut, "9",     "0111100010001000")


### PR DESCRIPTION
This should suffice to get `CUPCDN` working. Closes #300.