### PR TITLE
gowin_pack: fix invalid escape sequence

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -65,7 +65,7 @@ def sanitize_name(name):
         retname = name[:-4]
     if _verilog_name.fullmatch(retname):
         return retname
-    return f"\{retname} "
+    return f"\\{retname} "
 
 def extra_pll_bels(cell, row, col, num, cellname):
     # rPLL can occupy several cells, add them depending on the chip


### PR DESCRIPTION
This causes a warning to be printed on stderr when running `apicula.gowin_pack.main()` directly (but not via the CLI).