### PR TITLE
Add HCLK wires to PLL.

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -2860,7 +2860,7 @@ def route(db, tilemap, pips):
         try:
             if dest in tiledata.clock_pips:
                 bits = tiledata.clock_pips[dest][src]
-            elif is_himbaechel and (row - 1, col - 1) in db.hclk_pips and dest in db.hclk_pips[row - 1, col - 1]:
+            elif is_himbaechel and (row - 1, col - 1) in db.hclk_pips and dest in db.hclk_pips[row - 1, col - 1] and src in db.hclk_pips[row - 1, col - 1][dest]:
                 bits = db.hclk_pips[row - 1, col - 1][dest][src]
                 bits.update(do_hclk_banks(db, row - 1, col - 1, src, dest))
             else:

--- a/examples/blinky-pll.v
+++ b/examples/blinky-pll.v
@@ -8,7 +8,7 @@ module top (
 wire clk_w;
 
 rPLL pll(
-	    .CLKOUT(clk_w),  // 9MHz
+	    .CLKOUT(clk_w),
 		.CLKIN(clk),
 		.CLKFB(GND),
 		.RESET(GND),
@@ -40,7 +40,7 @@ rPLL pll(
 	defparam pll.DYN_FBDIV_SEL="false";
 	defparam pll.DYN_IDIV_SEL="false";
 	defparam pll.DYN_ODIV_SEL="false";
-	defparam pll.DYN_SDIV_SEL=1;      // 9MHz --- pixel clock
+	defparam pll.DYN_SDIV_SEL=2;
 	defparam pll.PSDA_SEL="0000";
 
 wire key = key_i ^ `INV_BTN;


### PR DESCRIPTION
Adds the ability to use high-speed clock lines (together with CLKDIV2 type frequency dividers operating on them) as signals for the CLKIN and CLKFB inputs of the rPLL and PLLVR primitives (these cover the full range of supported Gowin chips).