### PR TITLE
Implement the DLLDLY primitive.

### DIFF
--- a/apycula/attrids.py
+++ b/apycula/attrids.py
@@ -916,6 +916,30 @@ dcs_attrvals = {
         'VCC':             22,
         }
 
+# DLLDLY
+dlldly_attrids = {
+        'ENABLED':          0,
+        'LOADN':            2,
+        'SIGN':             3,
+        'MODE':             4,
+        'ADJ0':             5,
+        'ADJ1':             6,
+        'ADJ2':             7,
+        'ADJ3':             8,
+        'ADJ4':             9,
+        'ADJ5':            10,
+        'ADJ6':            11,
+        'ADJ7':            12,
+    }
+
+dlldly_attrvals = {
+        'UNKNOWN':          0,
+        'ENABLE':           1,
+        'NORMAL':           3,
+        '1':                4,
+        'NEG':              5,
+        }
+
 # DLL
 dll_attrids = {
         'CLKSEL':           0,

--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -2027,8 +2027,16 @@ def create_segments(dev, device):
             if (b_row, s_col, seg['bottom_gate_wire'][1]) in dev_desc['reserved_wires']:
                 seg['bottom_gate_wire'][1] = None
 
+            # remove isolated segments (these are in the DSP area of -9, -9C, -18, -18C)
+            if (not seg['top_gate_wire'][0] and not seg['top_gate_wire'][1]
+                and not seg['bottom_gate_wire'][0] and not seg['bottom_gate_wire'][1]):
+                del dev.segments[(top_gate_row, s_col, seg_idx)]
+
             # new segment i + 1
             seg_idx += 4
+            # XXX 6 and 7 need static DCS, disable for now
+            if seg_idx in [6, 7]:
+                continue
             seg_1 = dev.segments.setdefault((top_gate_row, s_col, seg_idx), {})
             # controlled area
             seg_1['min_x'] = seg['min_x']
@@ -2062,9 +2070,6 @@ def create_segments(dev, device):
                 seg_1['bottom_gate_wire'][1] = None
 
             # remove isolated segments (these are in the DSP area of -9, -9C, -18, -18C)
-            if (not seg['top_gate_wire'][0] and not seg['top_gate_wire'][1]
-                and not seg['bottom_gate_wire'][0] and not seg['bottom_gate_wire'][1]):
-                del dev.segments[(top_gate_row, s_col, seg_idx - 4)]
             if (not seg_1['top_gate_wire'][0] and not seg_1['top_gate_wire'][1]
                 and not seg_1['bottom_gate_wire'][0] and not seg_1['bottom_gate_wire'][1]):
                 del dev.segments[(top_gate_row, s_col, seg_idx)]

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -338,6 +338,16 @@ def parse_tile_(db, row, col, tile, default=True, noalias=False, noiostd = True)
     #    if attrvals:
     #        print(row, col, attrvals)
 
+    #if tiledata.ttyp in db.longfuses:
+    #    if 'DLLDEL0' in db.longfuses[tiledata.ttyp].keys():
+    #        attrvals =parse_attrvals(tile, db.logicinfo['DLLDLY'], db.longfuses[tiledata.ttyp]['DLLDEL0'], attrids.dlldly_attrids)
+    #        if attrvals:
+    #            print(row, col, attrvals)
+    #    if 'DLLDEL1' in db.longfuses[tiledata.ttyp].keys():
+    #        attrvals =parse_attrvals(tile, db.logicinfo['DLLDLY'], db.longfuses[tiledata.ttyp]['DLLDEL1'], attrids.dlldly_attrids)
+    #        if attrvals:
+    #            print(row, col, attrvals)
+
     clock_pips = {}
     bels = {}
     for name, bel in tiledata.bels.items():


### PR DESCRIPTION
DLLDLY is the clock delay primitive that adjust the input clock according to the DLLSTEP signal and outputs the delayed clock.

These primitives are associated with clock pins and are "tapped" between the output of this IBUF and the clock networks, leaving the possibility to connect to the original unshifted signal as well, although the latter is not very practical because it is no longer possible to use fast wires.