### PR TITLE
Fixed bitstream compression, tested on tangnano 9k hardware

### DIFF
--- a/apycula/bitmatrix.py
+++ b/apycula/bitmatrix.py
@@ -90,7 +90,8 @@ def histogram(lst, bins):
     """
     l_bins = len(bins) - 1
     r_lst = [0] * l_bins
-    for val in lst:
+    from itertools import chain
+    for val in chain.from_iterable(lst):
         for i in range(l_bins):
             if val in range(bins[i], bins[i + 1]) or (i == l_bins - 1 and val == bins[-1]):
                 r_lst[i] += 1

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -1,4 +1,5 @@
 from math import ceil
+import array
 import crc
 from apycula import bitmatrix
 
@@ -76,7 +77,7 @@ def read_bitstream(fname):
 def compressLine(line, key8Z, key4Z, key2Z):
     newline = []
     for i in range(0, len(line), 8):
-        val = line[i:i+8].tobytes().replace(8 * b'\x00', bytes([key8Z]))
+        val = array.array('B', line[i:i+8]).tobytes().replace(8 * b'\x00', bytes([key8Z]))
         val = val.replace(4 * b'\x00', bytes([key4Z]))
         newline += val.replace(2 * b'\x00', bytes([key2Z]))
     return newline

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -29,6 +29,8 @@ def read_bitstream(fname):
     preamble = 3
     frames = 0
     calc = crc.Calculator(crc16arc)
+    compressed = False
+    compress_keys = {}
     with open(fname) as inp:
         for line in inp:
             if line.startswith("//"): continue
@@ -36,6 +38,14 @@ def read_bitstream(fname):
             if not frames:
                 if is_hdr:
                     hdr.append(ba)
+                    if ba[0] == 0x10 and (int.from_bytes(ba, 'big') & (1 << 13)):
+                        compressed = True
+                    if ba[0] == 0x51:
+                        compress_keys[f'{ba[5]:08b}'] = 8
+                        if ba[6]:
+                            compress_keys[f'{ba[6]:08b}'] = 4
+                            if ba[7]:
+                                compress_keys[f'{ba[7]:08b}'] = 2
                 else:
                     ftr.append(ba)
                 if not preamble and ba[0] != 0xd2: # SPI address
@@ -44,22 +54,29 @@ def read_bitstream(fname):
                     frames = int.from_bytes(ba[2:], 'big')
                     is_hdr = False
                 if not preamble and ba[0] == 0x06: # device ID
-                    if ba == b'\x06\x00\x00\x00\x11\x00\x58\x1b':
+                    if ba == b'\x06\x00\x00\x00\x11\x00\x58\x1b':     # GW1N-9
                         padding = 4
-                    elif ba == b'\x06\x00\x00\x00\x11\x00H\x1b':
+                        compress_padding = 44
+                    elif ba == b'\x06\x00\x00\x00\x11\x00H\x1b':      # GW1N-9C
                         padding = 4
-                    elif ba == b'\x06\x00\x00\x00\x09\x00\x28\x1b':
+                        compress_padding = 44
+                    elif ba == b'\x06\x00\x00\x00\x09\x00\x28\x1b':   # GW1N-1
                         padding = 0
-                    elif ba == b'\x06\x00\x00\x00\x01\x008\x1b':
+                        compress_padding = 0
+                    elif ba == b'\x06\x00\x00\x00\x01\x008\x1b':      # GW1N-4
                         padding = 0
-                    elif ba == b'\x06\x00\x00\x00\x01\x00h\x1b':
+                        compress_padding = 8
+                    elif ba == b'\x06\x00\x00\x00\x01\x00h\x1b':      # GW1NZ-1
                         padding = 0
-                    elif ba == b'\x06\x00\x00\x00\x03\x00\x18\x1b':
+                        compress_padding = 0
+                    elif ba == b'\x06\x00\x00\x00\x03\x00\x18\x1b':   # XXX
                         padding = 0
-                    elif ba == b'\x06\x00\x00\x00\x01\x00\x98\x1b':
+                    elif ba == b'\x06\x00\x00\x00\x01\x00\x98\x1b':   # GW1NS-4
                         padding = 0
-                    elif ba == b'\x06\x00\x00\x00\x00\x00\x08\x1b':
+                        compress_padding = 8
+                    elif ba == b'\x06\x00\x00\x00\x00\x00\x08\x1b':   # GW2A-18(C)
                         padding = 0
+                        compress_padding = 16
                     else:
                         raise ValueError("Unsupported device", ba)
                 preamble = max(0, preamble-1)
@@ -69,7 +86,19 @@ def read_bitstream(fname):
             crc2 = calc.checksum(crcdat)
             assert crc1 == crc2, f"Not equal {crc1} {crc2} for {crcdat}"
             crcdat = ba[-6:]
-            bitmap.append(bitarr(line, padding))
+            if compressed:
+                uncompressed_line = ''
+                for byte_str in chunks(line[:-64], 8):
+                    if byte_str in compress_keys:
+                        for _ in range(compress_keys[byte_str]):
+                            uncompressed_line += "00000000"
+                    else:
+                        uncompressed_line += byte_str
+
+                uncompressed_line += line[-64:]
+                bitmap.append(bitarr(uncompressed_line, compress_padding))
+            else:
+                bitmap.append(bitarr(line, padding))
             frames = max(0, frames-1)
 
     return bitmatrix.fliplr(bitmap), hdr, ftr
@@ -78,8 +107,11 @@ def compressLine(line, key8Z, key4Z, key2Z):
     newline = []
     for i in range(0, len(line), 8):
         val = array.array('B', line[i:i+8]).tobytes().replace(8 * b'\x00', bytes([key8Z]))
-        val = val.replace(4 * b'\x00', bytes([key4Z]))
-        newline += val.replace(2 * b'\x00', bytes([key2Z]))
+        if key4Z:
+            val = val.replace(4 * b'\x00', bytes([key4Z]))
+            if key2Z:
+                val = val.replace(2 * b'\x00', bytes([key2Z]))
+        newline += val
     return newline
 
 def write_bitstream_with_bsram_init(fname, bs, hdr, ftr, compress, bsram_init):
@@ -96,19 +128,29 @@ def write_bitstream(fname, bs, hdr, ftr, compress):
     else:
         padlen = bitmatrix.shape(bs)[1] % 8
     pad = bitmatrix.ones(bitmatrix.shape(bs)[0], padlen)
+    no_compress_pad_bytes = (padlen - bitmatrix.shape(bs)[1] % 8) // 8
     bs = bitmatrix.hstack(pad, bs)
     assert bitmatrix.shape(bs)[1] % 8 == 0
     bs=bitmatrix.packbits(bs, axis = 1)
 
+    unused_bytes = []
     if compress:
         # search for smallest values not used in the bitstream
-        lst = bitmatrix.histogram(bs, bins=[i for i in range(257)]) # 257 iso that the last basket is [255, 256] and not [254, 255]
-        [key8Z, key4Z, key2Z] = [i for i,val in enumerate(lst) if val==0][0:3]
+        lst = bitmatrix.histogram(bs, bins=[i for i in range(257)]) # 257 so that the last basket is [255, 256] and not [254, 255]
+        unused_bytes = [i for i,val in enumerate(lst) if val==0]
+        if unused_bytes:
+            # We may simply not have the bytes we need for the keys.
+            [key8Z, key4Z, key2Z] = (unused_bytes + [0, 0])[0:3]
+            # update line 0x10 with compress enable bit
+            hdr10 = int.from_bytes(hdr[4], 'big') | (1 << 13)
+            hdr[4] = bytearray.fromhex(f"{hdr10:016x}")
 
-        # update line 0x51 with keys
-        hdr51 = int.from_bytes(hdr[5], 'big') & ~0xffffff
-        hdr51 = hdr51 | (key8Z << 16) | (key4Z << 8) | (key2Z)
-        hdr[5] = bytearray.fromhex(f"{hdr51:016x}")
+            # update line 0x51 with keys
+            hdr51 = int.from_bytes(hdr[5], 'big') & ~0xffffff
+            hdr51 = hdr51 | (key8Z << 16) | (key4Z << 8) | (key2Z)
+            hdr[5] = bytearray.fromhex(f"{hdr51:016x}")
+        else:
+            print("Warning. No unused bytes, will be uncompressed.")
 
     crcdat = bytearray()
     preamble = 3
@@ -122,7 +164,10 @@ def write_bitstream(fname, bs, hdr, ftr, compress):
             f.write('\n')
         for ba in bs:
             if compress:
-                ba = compressLine(ba, key8Z, key4Z, key2Z)
+                if unused_bytes:
+                    ba = compressLine(ba, key8Z, key4Z, key2Z)
+                else:
+                    ba = ba[no_compress_pad_bytes : ]
             f.write(''.join(f"{b:08b}" for b in ba))
             crcdat.extend(ba)
             crc_ = calc.checksum(crcdat)

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -2923,13 +2923,6 @@ def header_footer(db, bs, compress):
     # data in 16bit format
     res = int(sum(bs[0::2]) * pow(2,8) + sum(bs[1::2]))
     checksum = res & 0xffff
-
-    if compress:
-        # update line 0x10 with compress enable bit
-        # rest (keys) is done in bslib.write_bitstream
-        hdr10 = int.from_bytes(db.cmd_hdr[4], 'big') | (1 << 13)
-        db.cmd_hdr[4] = bytearray.fromhex(f"{hdr10:016x}")
-
     # set the checksum
     db.cmd_ftr[1] = bytearray.fromhex(f"{0x0A << 56 | checksum:016x}")
 

--- a/doc/compression.md
+++ b/doc/compression.md
@@ -16,7 +16,7 @@ Those values are stored in the header area (line starting with `0x51`), line sta
 
 This algorithm is applied 8 bytes by 8 bytes. So if lines are not multiple of 64bits, a serie of dummy bits (set to `1`) must be added.
 
-## select values to use
+## Select values to use
 
 This step consist to search all values not used for data/EBR configuration (it's more or less the creation of an histogram):
 ```python
@@ -32,7 +32,9 @@ unusedVal = [i for i,val in enumerate(lst) if val==0]
 - `key4Z` take the value for index 1
 - `key2Z` take the value for index 2 (highest value)
 
-line starting with `0x51` must be updated accordingly, and bit `13` for line `0x10` must be set
+There may not be enough unused values for some or all keys, in which case the key-specific packing is not performed (in the most severe case, the file is not packed at all if all possible byte values are used).
+
+Line starting with `0x51` must be updated accordingly, and bit `13` for line `0x10` must be set
 
 ## Conversion
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -234,7 +234,7 @@ clean:
 # ============================================================
 # Tangnano20k
 %-tangnano20k.fs: %-tangnano20k.json
-	gowin_pack -d GW2A-18C -o $@ $<
+	gowin_pack -c -d GW2A-18C -o $@ $<
 
 %-tangnano20k.json: %-tangnano20k-synth.json tangnano20k.cst
 	$(NEXTPNR) --json $< --write $@ --device GW2AR-LV18QN88C8/I7 --vopt family=GW2A-18C --vopt cst=tangnano20k.cst
@@ -257,7 +257,7 @@ dvi-example-tangnano20k-synth.json: DVI/dvi-example.v DVI/pll480.v DVI/tmds-chan
 # ============================================================
 # TangPrimer20k
 %-primer20k.fs: %-primer20k.json
-	gowin_pack -d GW2A-18 -o $@ $<
+	gowin_pack -c -d GW2A-18 -o $@ $<
 
 %-primer20k.json: %-primer20k-synth.json primer20k.cst
 	$(NEXTPNR) --json $< --write $@ --device GW2A-LV18PG256C8/I7 --vopt family=GW2A-18 --vopt cst=primer20k.cst
@@ -280,7 +280,7 @@ dvi-example-primer20k-synth.json: DVI/dvi-example.v DVI/pll480.v DVI/tmds-channe
 # ============================================================
 # Tangnano (GW1N-1)
 %-tangnano.fs: %-tangnano.json
-	gowin_pack -d GW1N-1 -o $@ $^
+	gowin_pack -c -d GW1N-1 -o $@ $^
 
 %-tangnano.json: %-tangnano-synth.json tangnano.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1N-LV1QN48C6/I5 --vopt cst=tangnano.cst
@@ -297,7 +297,7 @@ bsram-%-tangnano-synth.json: pll/GW1N-1-dyn.vh %-image-rom.v %-video-ram.v %.v
 # ============================================================
 # Tangnano1k (GW1NZ-1)
 %-tangnano1k.fs: %-tangnano1k.json
-	gowin_pack -d GW1NZ-1 -o $@ $^
+	gowin_pack -c -d GW1NZ-1 -o $@ $^
 
 %-tangnano1k.json: %-tangnano1k-synth.json tangnano1k.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1NZ-LV1QN48C6/I5 --vopt cst=tangnano1k.cst
@@ -306,7 +306,7 @@ bsram-%-tangnano-synth.json: pll/GW1N-1-dyn.vh %-image-rom.v %-video-ram.v %.v
 	$(YOSYS) -D LEDS_NR=3 -D OSC_TYPE_OSCZ -D INV_BTN=0 -D NUM_HCLK=4 -p "read_verilog $^; synth_gowin -json $@"
 
 pll-nanolcd-tangnano1k.fs: pll-nanolcd-tangnano1k.json
-	gowin_pack -d GW1NZ-1 --sspi_as_gpio --mspi_as_gpio -o $@ $^
+	gowin_pack -c -d GW1NZ-1 --sspi_as_gpio --mspi_as_gpio -o $@ $^
 
 pll-nanolcd-tangnano1k-synth.json: pll/GW1NZ-1-dyn.vh pll-nanolcd/TOP.v pll-nanolcd/VGAMod.v
 	$(YOSYS) -D INV_BTN=0 -p "read_verilog $^; synth_gowin -noalu -json $@"
@@ -317,7 +317,7 @@ bsram-%-tangnano1k-synth.json: pll/GW1NZ-1-dyn.vh %-image-rom.v %-video-ram.v %.
 # ============================================================
 # Tangnano4k (GW1NS-4)
 %-tangnano4k.fs: %-tangnano4k.json
-	gowin_pack -d GW1NS-4 --mspi_as_gpio -o $@ $^
+	gowin_pack -c -d GW1NS-4 --mspi_as_gpio -o $@ $^
 
 %-tangnano4k.json: %-tangnano4k-synth.json tangnano4k.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1NSR-LV4CQN48PC7/I6 --vopt cst=tangnano4k.cst
@@ -332,7 +332,7 @@ bsram-%-tangnano1k-synth.json: pll/GW1NZ-1-dyn.vh %-image-rom.v %-video-ram.v %.
 # ============================================================
 # Tangnano9k (GW1N-9C)
 %-tangnano9k.fs: %-tangnano9k.json
-	gowin_pack -d GW1N-9C -o $@ $^
+	gowin_pack -c -d GW1N-9C -o $@ $^
 
 %-tangnano9k.json: %-tangnano9k-synth.json tangnano9k.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1NR-LV9QN88PC6/I5 --vopt family=GW1N-9C --vopt cst=tangnano9k.cst
@@ -344,7 +344,7 @@ pll-nanolcd-tangnano9k-synth.json: pll/GW1N-9C-dyn.vh pll-nanolcd/TOP.v pll-nano
 	$(YOSYS) -D INV_BTN=0 -p "read_verilog $^; synth_gowin -json $@"
 
 pll-nanolcd-tangnano9k.fs: pll-nanolcd-tangnano9k.json
-	gowin_pack -d GW1N-9C --sspi_as_gpio --mspi_as_gpio -o $@ $^
+	gowin_pack -c -d GW1N-9C --sspi_as_gpio --mspi_as_gpio -o $@ $^
 
 bsram-%-tangnano9k-synth.json: pll/GW1N-9C-dyn.vh %-image-rom.v %-video-ram.v %.v
 	$(YOSYS) -D INV_BTN=0 -p "read_verilog $^; synth_gowin -json $@"
@@ -355,7 +355,7 @@ dvi-example-tangnano9k-synth.json: DVI/dvi-example.v DVI/pll480.v DVI/tmds-chann
 # ============================================================
 # szfpga miniboard (GW1N-9)
 %-miniszfpga.fs: %-miniszfpga.json
-	gowin_pack -d GW1N-9 -o $@ $<
+	gowin_pack -c -d GW1N-9 -o $@ $<
  
 %-miniszfpga.json: %-miniszfpga-synth.json miniszfpga.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1N-LV9QN48C6/I5 --vopt family=GW1N-9 --vopt cst=miniszfpga.cst
@@ -372,7 +372,7 @@ bsram-%-miniszfpga-synth.json: pll/GW1N-9-dyn.vh %-image-rom.v %-video-ram.v %.v
 # ============================================================
 # szfpga (GW1N-9)
 %-szfpga.fs: %-szfpga.json
-	gowin_pack -d GW1N-9 -o $@ $<
+	gowin_pack -c -d GW1N-9 -o $@ $<
  
 %-szfpga.json: %-szfpga-synth.json szfpga.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1NR-LV9LQ144PC6/I5 --vopt family=GW1N-9 --vopt cst=szfpga.cst
@@ -389,7 +389,7 @@ bsram-%-szfpga-synth.json: pll/GW1N-9-dyn.vh %-image-rom.v %-video-ram.v %.v
 # ============================================================
 # tec0117 (GW1N-9)
 %-tec0117.fs: %-tec0117.json
-	gowin_pack -d GW1N-9 -o $@ $<
+	gowin_pack -c -d GW1N-9 -o $@ $<
 
 %-tec0117.json: %-tec0117-synth.json tec0117.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1NR-LV9QN88C6/I5 --vopt family=GW1N-9 --vopt cst=tec0117.cst
@@ -403,7 +403,7 @@ blinky-pll-tec0117-synth.json: pll/GW1N-9-dyn.vh blinky-pll.v
 # ============================================================
 # runber (GW1N-4)
 %-runber.fs: %-runber.json
-	gowin_pack -d GW1N-4 -o $@ $<
+	gowin_pack -c -d GW1N-4 -o $@ $<
 
 %-runber.json: %-runber-synth.json runber.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1N-UV4LQ144C6/I5 --vopt cst=runber.cst


### PR DESCRIPTION
Bitstream compression (gowin_pack -c) seems broken after numpy is removed. This fixes it. 

The histogram version was broken because bs is actually a 2D array. Passing [y for x in bs for x in y] as a parameter would also work, but I just used built-in itertools for a (marginally) slight performance gain. 