### PR TITLE
Remove bitstream templates.

### DIFF
--- a/apycula/attrids.py
+++ b/apycula/attrids.py
@@ -1160,12 +1160,16 @@ osc_attrvals = {
 # config
 cfg_attrids = {
         'DONE_AS_GPIO':     0,
+        'GWD':              1,
         'GSR':              2,
+        'GOE':              3,
+        'DONE':             4,
         'JTAG_AS_GPIO':     6,
         'READY_AS_GPIO':    7,
         'MSPI_AS_GPIO':     8,
         'RECONFIG_AS_GPIO': 9,
         'SSPI_AS_GPIO':     10,
+        'POWERSAVE':        16,
         'I2C_AS_GPIO':      20,
         'JTAG_EN':          21,
         'POR':              24, # power on reset

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -117,12 +117,12 @@ def compressLine(line, key8Z, key4Z, key2Z):
 def write_bitstream_with_bsram_init(fname, bs, hdr, ftr, compress, bsram_init):
     new_bs = bitmatrix.vstack(bs, bsram_init)
     new_hdr = hdr.copy()
-    frames = int.from_bytes(new_hdr[-1][2:], 'big') + bitmatrix.shape(bsram_init)[0]
-    new_hdr[-1][2:] = frames.to_bytes(2, 'big')
     write_bitstream(fname, new_bs, new_hdr, ftr, compress)
 
 def write_bitstream(fname, bs, hdr, ftr, compress):
     bs = bitmatrix.fliplr(bs)
+    hdr[-1][2:] = bitmatrix.shape(bs)[0].to_bytes(2, 'big')
+
     if compress:
         padlen = (ceil(bitmatrix.shape(bs)[1] / 64) * 64) - bitmatrix.shape(bs)[1]
     else:

--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -76,7 +76,6 @@ class Device:
     pin_bank: Dict[str, int] = field(default_factory = dict)
     cmd_hdr: List[ByteString] = field(default_factory=list)
     cmd_ftr: List[ByteString] = field(default_factory=list)
-    template: List[List[int]] = None
     # allowable values of bel attributes
     # {table_name: [(attr_id, attr_value)]}
     logicinfo: Dict[str, List[Tuple[int, int]]] = field(default_factory=dict)

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -129,7 +129,7 @@ def store_bsram_init_val(db, row, col, typ, parms, attrs):
     if not has_bsram_init:
         has_bsram_init = True
         # 256 * bsram rows * chip bit width
-        bsram_init_map = bitmatrix.zeros(256 * len(db.simplio_rows), bitmatrix.shape(db.template)[1])
+        bsram_init_map = bitmatrix.zeros(256 * len(db.simplio_rows), db.width)
     # 3 BSRAM cells have width 3 * 60
     loc_map = bitmatrix.zeros(256, 3 * 60)
     #print("mapping")
@@ -2937,11 +2937,12 @@ def gsr(db, tilemap, args):
             add_attr_val(db, 'GSR', gsr_attrs, attrids.gsr_attrids[k], attrids.gsr_attrvals[val])
 
     cfg_attrs = set()
-    for k, val in {'GSR': 'USED'}.items():
+    for k, val in {'GSR': 'USED', 'GOE': 'F1'}.items():
         if k not in attrids.cfg_attrids:
             print(f'XXX CFG GSR: add {k} key handle')
         else:
             add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids[k], attrids.cfg_attrvals[val])
+    add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids['GSR'], attrids.cfg_attrvals['F1'])
 
     # The configuration fuses are described in the ['shortval'][60] table, global set/reset is
     # described in the ['shortval'][20] table. Look for cells with type with these tables
@@ -3056,15 +3057,15 @@ def main():
     _gnd_net = pnr['modules']['top']['netnames'].get(const_nets['GND'], {'bits': []})['bits']
     _vcc_net = pnr['modules']['top']['netnames'].get(const_nets['VCC'], {'bits': []})['bits']
 
-    tilemap = chipdb.tile_bitmap(db, db.template, empty=True)
+    tilemap = chipdb.tile_bitmap(db, bitmatrix.zeros(db.height, db.width), empty=True)
     cst = codegen.Constraints()
     pips = get_pips(pnr)
     route(db, tilemap, pips)
     isolate_segments(pnr, db, tilemap)
     bels = get_bels(pnr)
+    gsr(db, tilemap, args)
     # routing can add pass-through LUTs
     place(db, tilemap, itertools.chain(bels, _pip_bels) , cst, args)
-    gsr(db, tilemap, args)
     dualmode_pins(db, tilemap, args)
     # XXX Z-1 some kind of power saving for pll, disable
     # When comparing images with a working (IDE) and non-working PLL (apicula),

--- a/apycula/tiled_fuzzer.py
+++ b/apycula/tiled_fuzzer.py
@@ -270,7 +270,6 @@ if __name__ == "__main__":
     pnr_empty = run_pnr(codegen.Module(), codegen.Constraints(), {})
     db.cmd_hdr = pnr_empty.hdr
     db.cmd_ftr = pnr_empty.ftr
-    db.template = pnr_empty.bitmap
 
     # IOB
     diff_cap_info = pindef.get_diff_cap_info(device, params['package'], True)


### PR DESCRIPTION
We remove the original template from the chip base, which resulted from compiling an empty module.

Now there is no need in it - we set all the necessary bits ourselves.

At this point, the compilation call still remains - for header and footer.