### PR TITLE
Use a special case of the histogram.

### DIFF
--- a/apycula/bitmatrix.py
+++ b/apycula/bitmatrix.py
@@ -97,6 +97,17 @@ def histogram(lst, bins):
                 r_lst[i] += 1
     return r_lst
 
+def byte_histogram(lst):
+    """
+    Compute the histogram of a list of bytes.
+    Returns a list of 256 counters.
+    """
+    r_lst = [0] * 256
+    from itertools import chain
+    for val in chain.from_iterable(lst):
+        r_lst[val] += 1
+    return r_lst
+
 def any(bmp):
     """
     Test whether any matrix element evaluates to True.

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -136,7 +136,7 @@ def write_bitstream(fname, bs, hdr, ftr, compress):
     unused_bytes = []
     if compress:
         # search for smallest values not used in the bitstream
-        lst = bitmatrix.histogram(bs, bins=[i for i in range(257)]) # 257 so that the last basket is [255, 256] and not [254, 255]
+        lst = bitmatrix.byte_histogram(bs)
         unused_bytes = [i for i,val in enumerate(lst) if val==0]
         if unused_bytes:
             # We may simply not have the bytes we need for the keys.


### PR DESCRIPTION
Working with a fixed number (256) of baskets speeds up packing.

before
``` shell
% time gmake dsp-alu54d-miniszfpga.fs
gowin_pack -c -d GW1N-9 -o dsp-alu54d-miniszfpga.fs dsp-alu54d-miniszfpga.json
Warning. No unused bytes, will be uncompressed.
gmake dsp-alu54d-miniszfpga.fs  25,33s user 0,14s system 97% cpu 26,170 total
```

after
``` shell
% time gmake dsp-alu54d-miniszfpga.fs
gowin_pack -c -d GW1N-9 -o dsp-alu54d-miniszfpga.fs dsp-alu54d-miniszfpga.json
Warning. No unused bytes, will be uncompressed.
gmake dsp-alu54d-miniszfpga.fs  6,05s user 0,15s system 99% cpu 6,257 total
```