### PR TITLE
Don't compress EMCU examples.

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -2937,12 +2937,14 @@ def gsr(db, tilemap, args):
             add_attr_val(db, 'GSR', gsr_attrs, attrids.gsr_attrids[k], attrids.gsr_attrvals[val])
 
     cfg_attrs = set()
-    for k, val in {'GSR': 'USED', 'GOE': 'F1'}.items():
+    for k, val in {'GSR': 'USED', 'GOE': 'F0'}.items():
         if k not in attrids.cfg_attrids:
             print(f'XXX CFG GSR: add {k} key handle')
         else:
             add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids[k], attrids.cfg_attrvals[val])
-    add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids['GSR'], attrids.cfg_attrvals['F1'])
+    add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids['GSR'], attrids.cfg_attrvals['F0'])
+    add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids['DONE'], attrids.cfg_attrvals['F0'])
+    add_attr_val(db, 'CFG', cfg_attrs, attrids.cfg_attrids['GWD'], attrids.cfg_attrvals['F0'])
 
     # The configuration fuses are described in the ['shortval'][60] table, global set/reset is
     # described in the ['shortval'][20] table. Look for cells with type with these tables

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -319,6 +319,10 @@ bsram-%-tangnano1k-synth.json: pll/GW1NZ-1-dyn.vh %-image-rom.v %-video-ram.v %.
 %-tangnano4k.fs: %-tangnano4k.json
 	gowin_pack -c -d GW1NS-4 --mspi_as_gpio -o $@ $^
 
+# XXX fix compression with emcu
+emcu-%-tangnano4k.fs: emcu-%-tangnano4k.json
+	gowin_pack -d GW1NS-4 --mspi_as_gpio -o $@ $^
+
 %-tangnano4k.json: %-tangnano4k-synth.json tangnano4k.cst
 	$(NEXTPNR) --json $< --write $@ --device GW1NSR-LV4CQN48PC7/I6 --vopt cst=tangnano4k.cst
 


### PR DESCRIPTION
OpenFPGALoader frowns on checksum mismatch when loading images AND firmware of the Tangnano4k embedded processor when using compression.

Since cpu firmware is compiled separately from the FPGA image and completely different compilers and compression/uncompression independently and, in addition, it is possible and in practice very useful to use the same FPGA image, but change the CPU firmware, it is clear that we can not specify the checksum in the FPGA image taking into account the CPU firmware.

So I think that OpenFPGALoader's scolding here is groundless ;) and for now we do not use image compression in the EMCU examples.