### PR TITLE
Add SSTL entries to _vcc_ios dict in gowin_pack

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -2304,7 +2304,9 @@ _default_iostd = {
         'ELVDS_IOBUF': 'LVCMOS33D',
         }
 _vcc_ios = {'LVCMOS12': '1.2', 'LVCMOS15': '1.5', 'LVCMOS18': '1.8', 'LVCMOS25': '2.5',
-        'LVCMOS33': '3.3', 'LVDS25': '2.5', 'LVCMOS33D': '3.3', 'LVCMOS_D': '3.3', 'MIPI': '1.2'}
+        'LVCMOS33': '3.3', 'LVDS25': '2.5', 'LVCMOS33D': '3.3', 'LVCMOS_D': '3.3', 'MIPI': '1.2',
+        'SSTL15': '1.5', 'SSTL18_I': '1.8', 'SSTL18_II': '1.8', 'SSTL25_I': '2.5', 'SSTL25_II': '2.5', 'SSTL33_I': '3.3', 'SSTL33_II': '3.3',
+        'SSTL15D': '1.5', 'SSTL18D_I': '1.8', 'SSTL18D_II': '1.8', 'SSTL25D_I': '2.5', 'SSTL25D_II': '2.5', 'SSTL33D_I': '3.3', 'SSTL33D_II': '3.3'}
 _init_io_attrs = {
         'IBUF': {'PADDI': 'PADDI', 'HYSTERESIS': 'NONE', 'PULLMODE': 'UP', 'SLEWRATE': 'SLOW',
                  'DRIVE': '0', 'CLAMP': 'OFF', 'OPENDRAIN': 'OFF', 'DIFFRESISTOR': 'OFF',


### PR DESCRIPTION
Fixes https://github.com/YosysHQ/apicula/issues/361.

This Pull Request adds entries in the `_vcc_ios` dict in `gowin_pack.py` for the various SSTL IO types. The source of truth for the newly added keys was taken from the `frozenset`'s in the `_iostd_alias` dict.

This fixes a bug where `gowin_pack` fails to pack the bitstream if any IO is defined as `SSTL` as it cannot lookup the voltage in the `_vcc_ios` dict:
```
  File "/home/user/oss-cad-suite/lib/python3.11/site-packages/apycula/gowin_pack.py", line 2725, in place
    vccio = _vcc_ios[iostd]
            ~~~~~~~~^^^^^^^
KeyError: 'SSTL15'
```

Or alternatively, if a `BANK_VCCIO` is also specified for that IO port, there is a key error when trying to validate that it matches based on the IO type:
```
  File "/home/user/oss-cad-suite/lib/python3.11/site-packages/apycula/gowin_pack.py", line 2720, in place
    if iob.attrs['BANK_VCCIO'] != _vcc_ios[iob.attrs['IO_TYPE']]:
                                  ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'SSTL15'
```