### PR TITLE
GW5A. Add CPU/SSPI contact mode switching.

### DIFF
--- a/apycula/attrids.py
+++ b/apycula/attrids.py
@@ -1191,6 +1191,7 @@ cfg_attrids = {
         'I2C_AS_GPIO':      20,
         'JTAG_EN':          21,
         'POR':              24, # power on reset
+        'CPU_AS_GPIO':      28,
     }
 
 cfg_attrvals = {

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -2990,7 +2990,8 @@ def gsr(db, tilemap, args):
 
 def dualmode_pins(db, tilemap, args):
     pin_flags = {'JTAG_AS_GPIO': 'UNKNOWN', 'SSPI_AS_GPIO': 'UNKNOWN', 'MSPI_AS_GPIO': 'UNKNOWN',
-            'DONE_AS_GPIO': 'UNKNOWN', 'RECONFIG_AS_GPIO': 'UNKNOWN', 'READY_AS_GPIO': 'UNKNOWN'}
+            'DONE_AS_GPIO': 'UNKNOWN', 'RECONFIG_AS_GPIO': 'UNKNOWN', 'READY_AS_GPIO': 'UNKNOWN',
+                 'CPU_AS_GPIO': 'UNKNOWN'}
     if args.jtag_as_gpio:
         pin_flags['JTAG_AS_GPIO'] = 'YES'
     if args.sspi_as_gpio:
@@ -3003,6 +3004,8 @@ def dualmode_pins(db, tilemap, args):
         pin_flags['DONE_AS_GPIO'] = 'YES'
     if args.reconfign_as_gpio:
         pin_flags['RECONFIG_AS_GPIO'] = 'YES'
+    if args.cpu_as_gpio:
+        pin_flags['CPU_AS_GPIO'] = 'YES'
 
     set_attrs = set()
     clr_attrs = set()
@@ -3057,6 +3060,7 @@ def main():
     parser.add_argument('--ready_as_gpio', action = 'store_true')
     parser.add_argument('--done_as_gpio', action = 'store_true')
     parser.add_argument('--reconfign_as_gpio', action = 'store_true')
+    parser.add_argument('--cpu_as_gpio', action = 'store_true')
     if pil_available:
         parser.add_argument('--png')
 

--- a/examples/gw5a/Makefile
+++ b/examples/gw5a/Makefile
@@ -16,7 +16,7 @@ clean:
 # ============================================================
 # TangPrimer25k
 %-primer25k.fs: %-primer25k.json
-	gowin_pack -d GW5A-25A -o $@ $<
+	gowin_pack -d GW5A-25A --cpu_as_gpio -o $@ $<
 
 %-primer25k.json: %-primer25k-synth.json primer25k.cst
 	$(NEXTPNR) -v --debug --top top --json $< --write $@ --device GW5A-LV25MG121NES --vopt cst=primer25k.cst


### PR DESCRIPTION
The TangPrimer25k board is designed so that the external quartz resonator is soldered to the E2 input, which is the communication line to the CPU/SSPI.

Without further ado, we add a command line flag to use it as a GPIO to receive the clock signal.