### PR TITLE
GW5A. Masquerade for memory cells.

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -2811,6 +2811,8 @@ def from_fse(device, fse, dat: Datfile):
     fse_create_tile_types(dev, dat)
     #XXX
     if device in {'GW5A-25A'}:
+        dev.tile_types.setdefault('C', set()).update(dev.tile_types['M'])
+        dev.tile_types['M'] = set()
         dev.tile_types['P'] = set()
         dev.tile_types['B'] = set()
         dev.tile_types['D'] = set()


### PR DESCRIPTION
Since only ROM16 is supported from the "normal" LUTRAM modes in the GW5A series, we do not let nextpnr think that we have full memory. We mask the cells as normal logic.

This temporary measure will work well until we have to implement the 60K chip option, at which point we will change nextpnr.