### PR TITLE
Send the gate wires to the nextpnr.

### DIFF
--- a/apycula/chipdb.py
+++ b/apycula/chipdb.py
@@ -2308,6 +2308,8 @@ def fse_create_logic2clk(dev, device, dat: Datfile):
         if row != -2:
             add_node(dev, wnames.clknames[clkwire_idx], "GLOBAL_CLK", row, col, wnames.wirenames[wire_idx])
             add_buf_bel(dev, row, col, wnames.wirenames[wire_idx])
+            # Make list of the clock gates for nextpnr
+            dev.extra_func.setdefault((row, col), {}).setdefault('clock_gates', []).append(wnames.wirenames[wire_idx])
 
 def fse_create_osc(dev, device, fse):
     for row, rd in enumerate(dev.grid):


### PR DESCRIPTION
We pass information about gate wires to nextpnr, since it is possible to connect them as sinks to PIPs, where the clock wires themselves act as sources, which can lead to looping.