### PR TITLE
Fix ALU.

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -2362,6 +2362,9 @@ def place_alu(db, tiledata, tile, parms, num, row, col, slice_attrvals):
     for r_c in lutmap.values():
         for r, c in r_c:
             tile[r][c] = 0
+    # XXX Fix for bug in nextpnr 0.9, will be unnecessary with the next release.
+    if parms['ALU_MODE'] == "0 ":
+        parms['RAW_ALU_LUT'] = "0011000011001100"
     # ALU_RAW_LUT - bits for ALU LUT init value, which are formed in nextpnr as
     # a result of optimization.
     if 'RAW_ALU_LUT' in parms:


### PR DESCRIPTION
When CARRY is generated in logic, nextpnr v0.9 outputs incorrect parameters for the first ALU in the chain.

A fix for nextpnr is already in the works, but it will only be included in the next release, so we are adding a workaround to apicula to support both 0.9 and subsequent releases of nextpnr.