### PR TITLE
25A unusual IOs.

### DIFF
--- a/apycula/attrids.py
+++ b/apycula/attrids.py
@@ -260,7 +260,8 @@ iob_attrvals = {
             'LVCMOS33OD12':     161,
             'LVCMOS25OD12':     162,
             'LVCMOS18OD12':     163,
-
+            # voltage
+            '1.0':              193,
             # 5A ADC
             'UNKNOWN247':       247,
             'UNKNOWN254':       254,

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -3543,6 +3543,9 @@ def place(db, tilemap, bels, cst, args, slice_attrvals, extra_slots):
                         fuse_row += off[0]
                         fuse_col += off[1]
                         fuse_ttyp = db.grid[fuse_row][fuse_col].ttyp
+                    # IOR3 A and B are actually A only in different cells
+                    if (row, col, iob_idx) == (2, 91, 'B'):
+                        iob_idx = 'A'
                     bits = get_longval_fuses(db, fuse_ttyp, iob_attrs, f'IOB{iob_idx}')
 
                 tile = tilemap[(fuse_row, fuse_col)]


### PR DESCRIPTION
TangPrimer25k with the GW5A-25A chip has interesting I/O pins that are strikingly different from most I/O pins.

These are:

 - IOT92A (TCK) with pins I:A6, OE:A7, O:OF7

 - IOT92B (TDI) with pins I:SEL1, OE:SEL2, O:Q5

 - IOR3A (TMS) with pins I:A0, OE:A1, O:Q3

 - IOR3B (TDO) with pins I:B0, OE:B1, O:Q4

 - IOB1A (RECONFIG_N) with pins I:C0, OE:C1, O:F2

 - IOB64A (DONE) with pins I:SEL0, OE:SEL1, O:F7

IOR3A and IOR3B are actually both A, and this fact must be taken into account.

Finally, it should be noted that the TangPrimer25k dock has enough GPIOs, and using these special pins is not the best idea.