### PR TITLE
Read information about banks from a DAT file.

### DIFF
--- a/apycula/dat19.py
+++ b/apycula/dat19.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 from dataclasses import dataclass
 
-
 @dataclass
 class Primitive:
     name: str
@@ -38,14 +37,13 @@ class Datfile:
         if partType == 0:       # 1/2 Series
             self.compat_dict.update(self.read_something())
         elif partType == 1:
-            print(f"PartType {partType} is not supported")
-
+            raise Exception(f"PartType {partType} is not supported")
         elif partType == 2:  # 5 Series
             self.gw5aStuff = self.read_5Astuff()
-            self.compat_dict.update(self.read_something5A())
-
+            self.compat_dict.update(self.read_something())
         elif partType == 4:
-            print(f"PartType {partType} is not supported")
+            raise Exception(f"PartType {partType} is not supported")
+
 
         self.compat_dict.update(self.read_io())
         self.cmux_ins: dict[int, list[int]] = self.read_io()['CmuxIns']

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -3568,7 +3568,7 @@ def place(db, tilemap, bels, cst, args, slice_attrvals, extra_slots):
                 if k in {'BANK_VCCIO', 'IO_TYPE', 'LVDS_OUT', 'DRIVE', 'OPENDRAIN'}:
                     add_attr_val(db, 'IOB', bank_attrs, attrids.iob_attrids[k], attrids.iob_attrvals[val])
 
-        bits = get_bank_fuses(db, tiledata.ttyp, bank_attrs, 'BANK', int(bank))
+        bits = get_bank_fuses(db, tiledata.ttyp, bank_attrs, 'BANK', bank)
         bits.update(get_bank_io_fuses(db, tiledata.ttyp, bank_attrs))
 
         btile = tilemap[(brow, bcol)]

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -1309,7 +1309,7 @@ def main():
         bm[(45, 55)] = bm_pll[(45, 55)]
 
     # banks first: need to know iostandards
-    for pos in db.corners.keys():
+    for pos in db.bank_tiles.values():
         row, col = pos
         try:
             t = bm[(row, col)]
@@ -1321,8 +1321,8 @@ def main():
 
     for idx, t in bm.items():
         row, col = idx
-        # skip banks & dual pisn
-        if (row, col) in db.corners:
+        # skip banks
+        if (row, col) in db.bank_tiles.values():
             continue
         bels, pips, clock_pips = parse_tile_(db, row, col, t, bm, noiostd = False)
         #print("bels:", idx, bels)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -380,7 +380,7 @@ bsram-%-miniszfpga-synth.json: pll/GW1N-9-dyn.vh io565.vh display-480x272.v %-im
 	gowin_pack -c -d GW1N-9 -o $@ $<
  
 %-szfpga.json: %-szfpga-synth.json szfpga.cst
-	$(NEXTPNR) --json $< --write $@ --device GW1NR-LV9LQ144PC6/I5 --vopt family=GW1N-9 --vopt cst=szfpga.cst
+	$(NEXTPNR) --seed=3 --json $< --write $@ --device GW1NR-LV9LQ144PC6/I5 --vopt family=GW1N-9 --vopt cst=szfpga.cst
 
 %-szfpga-synth.json: %.v
 	$(YOSYS) -D LEDS_NR=4 -D OSC_TYPE_OSC -D INV_BTN=0 -D CPU_FREQ=50 -D BAUD_RATE=115200 -D NUM_HCLK=5 -p "read_verilog $^; synth_gowin -json $@ ${YOSYS_FLAGS}"

--- a/examples/blinky-oddr.v
+++ b/examples/blinky-oddr.v
@@ -24,7 +24,7 @@ end
 // Combinational code (boolean logic)
 assign ctr_d = ctr_q + 1'b1;
 assign led[`LEDS_NR-1:2] = {(`LEDS_NR - 2){1'b1}};
-assign led[0] = ctr_q[24:24];
+assign led[0] = ~ctr_q[24:24];
 
 wire aux_wire;
 


### PR DESCRIPTION
We are changing the source of information about the banks to which IOs belong. Previously, this information was obtained from a specific package, but now it will be taken from the DAT file that describes the chip.

This will allow you to work with pins that are not exposed in any package. You cannot do much with them, but it is advisable to set them to ‘not used’ status.