### PR TITLE
Enable ‘Byte Enable’ on BSRAM. for all chips, including the 5A series.

### DIFF
--- a/apycula/attrids.py
+++ b/apycula/attrids.py
@@ -869,14 +869,14 @@ bsram_attrids = {
         'ROMA_DATA_WIDTH':  56,
         'ROMB_DATA_WIDTH':  57,
         'ROM_DATA_WIDTH':   58,
-        'ROM_PORTA_BEHB':   59,
-        'ROM_PORTA_BELB':   60,
+        'ROMA_BEHB':        59,
+        'ROMA_BELB':        60,
         'ROMA_REGMODE':     61,
         'ROMB_REGMODE':     62,
-        'PORTB_BELB':       63,
-        'PORTA_MODE':       64,
-        'PORTB_MODE':       65,
-        'PORTB_BEHB':       66
+        'ROMB_BELB':        63,
+        'ROMA_MODE':        64,
+        'ROMB_MODE':        65,
+        'ROMB_BEHB':        66
     }
 
 bsram_attrvals = {
@@ -894,7 +894,8 @@ bsram_attrvals = {
         'WT':               11,
         'OUTREG':           12,
         'DISABLE':          13,
-        'RESET':            14
+        'RESET':            14,
+        'NORMAL':           15,
     }
 
 # slice

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -389,7 +389,7 @@ def parse_tile_(db, row, col, tile, bm=None, default=True, noiostd = True):
             attrvals = parse_attrvals(tile, db.rev_logicinfo('BSRAM'), db.shortval[tiledata.ttyp]['BSRAM_SP'], attrids.bsram_attrids, "BSRAM")
             if not attrvals:
                 continue
-            #print(row, col, name, idx, tiledata.ttyp, attrvals)
+            print(row, col, name, idx, tiledata.ttyp, attrvals)
             bels[f'{name}{idx}'] = {}
             continue
         if name.startswith("ALU54D"):

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -328,10 +328,10 @@ emcu-%-tangnano4k.fs: emcu-%-tangnano4k.json
 	$(NEXTPNR) --json $< --write $@ --device GW1NSR-LV4CQN48PC7/I6 --vopt cst=tangnano4k.cst
 
 %-tangnano4k-synth.json: %.v
-	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSCZ -D INV_BTN=0 -D FORCE_BRAM -D CPU_FREQ=27 -D BAUD_RATE=115200 -D NUM_HCLK=2 -D RISCV_MEM_16K -p "read_verilog $^; synth_gowin -json $@ ${YOSYS_FLAGS}"
+	$(YOSYS) -D LEDS_NR=6 -D OSC_TYPE_OSCZ -D INV_BTN=0 -D FORCE_BRAM -D CPU_FREQ=27 -D BAUD_RATE=115200 -D NUM_HCLK=2 -D RISCV_MEM_16K -p "read_verilog $^; synth_gowin -nolutram -nowidelut -json $@ ${YOSYS_FLAGS}"
 
 %-pll-tangnano4k-synth.json: pll/GW1NS-4-dyn.vh %-pll-vr.v
-	$(YOSYS) -D INV_BTN=0 -D LEDS_NR=6 -p "read_verilog $^; synth_gowin -json $@ ${YOSYS_FLAGS}"
+	$(YOSYS) -D INV_BTN=0 -D LEDS_NR=6 -p "read_verilog $^; synth_gowin -nolutram -json $@ ${YOSYS_FLAGS}"
 	
 
 # ============================================================

--- a/examples/femto-riscv-15.v
+++ b/examples/femto-riscv-15.v
@@ -44,7 +44,7 @@ module Memory (
 
    reg [31:0] MEM [0:255]; 
 
-   localparam slow_bit=22;
+   localparam slow_bit=21;
    
 `include "riscv_assembly.v"
    integer L0_   = 8;

--- a/examples/femto-riscv-16.v
+++ b/examples/femto-riscv-16.v
@@ -45,7 +45,7 @@ module Memory (
 
    reg [31:0] MEM [0:255]; 
 
-   localparam slow_bit=20;
+   localparam slow_bit=21;
    
 `include "riscv_assembly.v"
    integer L0_   = 12;


### PR DESCRIPTION
Enable ‘Byte Enable’ on BSRAM for all chips, including the 5A series.

This can effectively reduce the number of BSRAM blocks used by a factor of 4.