### PR TITLE
Implement GW5AST-138C clock system.

### DIFF
--- a/apycula/attrids.py
+++ b/apycula/attrids.py
@@ -1307,7 +1307,10 @@ cfg_attrids = {
         'I2C_AS_GPIO':      20,
         'JTAG_EN':          21,
         'POR':              24, # power on reset
-        'CPU_AS_GPIO':      28,
+        'CPU_AS_GPIO_25':   28, # GW5A-25A
+        'CPU_AS_GPIO_0':    34, # GW5AST-138C
+        'CPU_AS_GPIO_1':    35, # GW5AST-138C
+        'CPU_AS_GPIO_2':    37,
     }
 
 cfg_attrvals = {

--- a/apycula/dat19.py
+++ b/apycula/dat19.py
@@ -330,8 +330,8 @@ class Datfile:
         ret["Ae350SocOuts"]         = self.read_scaledGrid16(0x206, 3, 3, RSTable5ATOffset + 0x8bb0, 10)
 
 
-        ret["CMuxTopInNodes"]       = self.read_scaledGrid16(0xbd, 0x54, 0x54, RSTable5ATOffset + 0x13fc4, 0)
-        ret["CMuxBotInNodes"]       = self.read_scaledGrid16(0xbd, 0x54, 0x54, RSTable5ATOffset + 0x1bbcc, 0)
+        ret["CMuxTopInNodes"]       = self.read_scaledGrid16(0xbd, 0x54, 0x54 * 2, 1, RSTable5ATOffset + 0x14af4)
+        ret["CMuxBotInNodes"]       = self.read_scaledGrid16(0xbd, 0x54, 0x54 * 2, 1, RSTable5ATOffset + 0x1c6fc)
         ret["CMuxTopIns"]           = self.read_scaledGrid16i(0xbd, 3, 6, 1, RSTable5ATOffset + 0x24304)
         ret["CMuxBotIns"]           = self.read_scaledGrid16i(0xbd, 3, 6, 1, RSTable5ATOffset + 0x24772)
 

--- a/apycula/fuse_h4x.py
+++ b/apycula/fuse_h4x.py
@@ -18,12 +18,12 @@ def readFse(f, device):
     print("check", rint(f, 4))
     tiles = {}
     ttyp = rint(f, 4)
-    print(f"tile type:{ttyp}/{hex(ttyp)}")
+    #print(f"tile type:{ttyp}/{hex(ttyp)}")
     tiles['header'] = readOneFile(f, ttyp, device)
     while True:
         ttyp = rint(f, 4)
         if ttyp == 0x9a1d85: break
-        print(f"tile type:{ttyp}/{hex(ttyp)}")
+        #print(f"tile type:{ttyp}/{hex(ttyp)}")
         tiles[ttyp] = readOneFile(f, ttyp, device)
     return tiles
 
@@ -35,7 +35,7 @@ def readOneFile(f, tileType, device):
     tmap = {"height": rint(f, 4),
             "width": rint(f, 4)}
     tables = rint(f, 4)
-    print("height: ", tmap["height"], "width: ", tmap["width"], "tables:", tables)
+    #print("height: ", tmap["height"], "width: ", tmap["width"], "tables:", tables)
 
     #v1 = 0x1b8
     #v2 = 3
@@ -56,7 +56,7 @@ def readOneFile(f, tileType, device):
     for i in range(tables):
         typ = rint(f, 4)
         size = rint(f, 4)
-        print(hex(f.tell()), " Table type", typ, "/", hex(typ), "of size", size)
+        #print(hex(f.tell()), " Table type", typ, "/", hex(typ), "of size", size)
         if typ == 61:
             size2 = rint(f, 4)
             typn = "grid"
@@ -413,7 +413,7 @@ def scan_tables(d, tiletyp, fuses):
             for row in table:
                 row_fuses = fuses.intersection(row)
                 if row_fuses:
-                    print(f"fuses {row_fuses} found in {tname}({ttyp}): {row}")
+                    #print(f"fuses {row_fuses} found in {tname}({ttyp}): {row}")
                     res.append(row)
     return res
 

--- a/apycula/wirenames.py
+++ b/apycula/wirenames.py
@@ -191,7 +191,7 @@ hclknames_pre5a[278] = 'VSS'
 hclknumbers_pre5a = {v: k for k, v in hclknames_pre5a.items()}
 
 """ *********************************************************************************
-     Names and encoding of wires of the 5A series chips
+     Names and encoding of wires of the 5A25A series chips
     *********************************************************************************
 """
 wirenames_5a25a = { 0: "A0", 1: "B0", 2: "C0", 3: "D0", 4: "A1", 5: "B1", 6: "C1", 7: "D1", 8: "A2", 9: "B2", 10: "C2", 11: "D2", 12: "A3", 13: "B3", 14: "C3",
@@ -263,9 +263,6 @@ clknames_5a25a.update({
      76: 'P47A', 77: 'P47B', 78: 'P47C', 79: 'P47D'
 })
 clknames_5a25a[80] = 'VSS'
-# each PLL has 4 delay-critical outputs (clkout, clkoutp, clkoutd, clkoutd3),
-# their numbers are listed here, the names indicate the possible location of
-# the PLL (Top Left etc):
 clknames_5a25a.update({
      81: 'PLL4CLKOUT0',  82: 'PLL4CLKOUT1',  83: 'PLL4CLKOUT2',  84: 'PLL4CLKOUT3',
      85: 'PLL4CLKOUT4',  86: 'PLL4CLKOUT5',  87: 'PLL4CLKOUT6',  88: 'PLL4CLKOUT7',
@@ -393,6 +390,190 @@ hclknames_5a25a.update({n: f"HCLK_GCLK3{i}" for i, n in enumerate(range(684, 692
 
 hclknumbers_5a25a = {v: k for k, v in hclknames_5a25a.items()}
 
+""" *********************************************************************************
+     Names and encoding of wires of the 5AST138C series chips
+    *********************************************************************************
+"""
+wirenames_5ast138c = { 0: "A0", 1: "B0", 2: "C0", 3: "D0", 4: "A1", 5: "B1", 6: "C1", 7: "D1", 8: "A2", 9: "B2", 10: "C2", 11: "D2", 12: "A3", 13: "B3", 14: "C3",
+15: "D3", 16: "A4", 17: "B4", 18: "C4", 19: "D4", 20: "A5", 21: "B5", 22: "C5", 23: "D5", 24: "A6", 25: "B6", 26: "C6", 27: "D6", 28: "A7", 29: "B7",
+30: "C7", 31: "D7", 32: "F0", 33: "F1", 34: "F2", 35: "F3", 36: "F4", 37: "F5", 38: "F6", 39: "F7", 40: "Q0", 41: "Q1", 42: "Q2", 43: "Q3", 44: "Q4",
+45: "Q5", 46: "Q6", 47: "Q7", 48: "OF0", 49: "OF1", 50: "OF2", 51: "OF3", 52: "OF4", 53: "OF5", 54: "OF6", 55: "OF7", 56: "X01", 57: "X02", 58: "X03",
+59: "X04", 60: "X05", 61: "X06", 62: "X07", 63: "X08", 64: "N100", 65: "SN10", 66: "SN20", 67: "N130", 68: "S100", 69: "S130", 70: "E100", 71: "EW10",
+72: "EW20", 73: "E130", 74: "W100", 75: "W130", 76: "N200", 77: "N210", 78: "N220", 79: "N230", 80: "N240", 81: "N250", 82: "N260", 83: "N270", 84: "S200",
+85: "S210", 86: "S220", 87: "S230", 88: "S240", 89: "S250", 90: "S260", 91: "S270", 92: "E200", 93: "E210", 94: "E220", 95: "E230", 96: "E240", 97: "E250",
+98: "E260", 99: "E270", 100: "W200", 101: "W210", 102: "W220", 103: "W230", 104: "W240", 105: "W250", 106: "W260", 107: "W270", 108: "N800", 109: "N810",
+110: "N820", 111: "N830", 112: "S800", 113: "S810", 114: "S820", 115: "S830", 116: "E800", 117: "E810", 118: "E820", 119: "E830", 120: "W800", 121: "W810",
+122: "W820", 123: "W830", 124: "CLK0", 125: "CLK1", 126: "CLK2", 127: "LSR0", 128: "LSR1", 129: "LSR2", 130: "CE0", 131: "CE1", 132: "CE2", 133: "SEL0",
+134: "SEL1", 135: "SEL2", 136: "SEL3", 137: "SEL4", 138: "SEL5", 139: "SEL6", 140: "SEL7", 141: "N101", 142: "N131", 143: "S101", 144: "S131", 145: "E101", 146: "E131",
+147: "W101", 148: "W131", 149: "N201", 150: "N211", 151: "N221", 152: "N231", 153: "N241", 154: "N251", 155: "N261", 156: "N271", 157: "S201", 158: "S211",
+159: "S221", 160: "S231", 161: "S241", 162: "S251", 163: "S261", 164: "S271", 165: "E201", 166: "E211", 167: "E221", 168: "E231", 169: "E241", 170: "E251",
+171: "E261", 172: "E271", 173: "W201", 174: "W211", 175: "W221", 176: "W231", 177: "W241", 178: "W251", 179: "W261", 180: "W271", 181: "N202", 182: "N212",
+183: "N222", 184: "N232", 185: "N242", 186: "N252", 187: "N262", 188: "N272", 189: "S202", 190: "S212", 191: "S222", 192: "S232", 193: "S242", 194: "S252",
+195: "S262", 196: "S272", 197: "E202", 198: "E212", 199: "E222", 200: "E232", 201: "E242", 202: "E252", 203: "E262", 204: "E272", 205: "W202", 206: "W212",
+207: "W222", 208: "W232", 209: "W242", 210: "W252", 211: "W262", 212: "W272", 213: "N804", 214: "N814", 215: "N824", 216: "N834", 217: "S804", 218: "S814",
+219: "S824", 220: "S834", 221: "E804", 222: "E814", 223: "E824", 224: "E834", 225: "W804", 226: "W814", 227: "W824", 228: "W834", 229: "N808", 230: "N818",
+231: "N828", 232: "N838", 233: "S808", 234: "S818", 235: "S828", 236: "S838", 237: "E808", 238: "E818", 239: "E828", 240: "E838", 241: "W808", 242: "W818",
+243: "W828", 244: "W838", 245: "E110", 246: "W110", 247: "E120", 248: "W120", 249: "S110", 250: "N110", 251: "S120", 252: "N120", 253: "E111", 254: "W111",
+255: "E121", 256: "W121", 257: "S111", 258: "N111", 259: "S121", 260: "N121", 261: "LB01", 262: "LB11", 263: "LB21", 264: "LB31", 265: "LB41", 266: "LB51",
+267: "LB61", 268: "LB71", 269: "GB00", 270: "GB10", 271: "GB20", 272: "GB30", 273: "GB40", 274: "GB50", 275: "GB60", 276: "GB70", 277: "VCC", 278: "VSS",
+279: "LT00", 280: "LT10", 281: "LT20", 282: "LT30", 283: "LT02", 284: "LT13", 285: "LT01", 286: "LT04", 287: "LBO0", 288: "LBO1", 289: "SS00", 290: "SS40",
+291: "GT00", 292: "GT10", 293: "GBO0", 294: "GBO1", 295: "DI0", 296: "DI1", 297: "DI2", 298: "DI3", 299: "DI4", 300: "DI5", 301: "DI6", 302: "DI7",
+             303: "CIN0", 304: "CIN1", 305: "CIN2", 306: "CIN3", 307: "CIN4", 308: "CIN5", 309: "COUT0", 310: "COUT1", 311: "COUT2", 312: "COUT3", 313: "COUT4", 314: "COUT5", 315: "SPCLK_0", 316: "SPCLK_1"}
+
+wirenames_5ast138c.update({n: f"UNK{n}" for n in range(506, 569)})
+
+wirenames_5ast138c.update({n: f"LWSPINETL{n - 1001}" for n in range(1001, 1009)})
+wirenames_5ast138c.update({n: f"LWSPINETR{n - 1009}" for n in range(1009, 1017)})
+wirenames_5ast138c.update({n: f"LWSPINEBL{n - 1017}" for n in range(1017, 1025)})
+wirenames_5ast138c.update({n: f"LWSPINEBR{n - 1025}" for n in range(1025, 1033)})
+wirenames_5ast138c.update({n: f"LWSPINEB1L{n - 1033}" for n in range(1033, 1041)})
+wirenames_5ast138c.update({n: f"LWSPINEB1R{n - 1041}" for n in range(1041, 1049)})
+
+wirenames_5ast138c.update({n: f"UNK{n}" for n in range(1049, 1241)})
+
+wirenames_5ast138c.update({n: f"5A{n}" for n in range(545, 553)}) # GW5A-25A need these
+wirenames_5ast138c.update({n: f"5A{n}" for n in range(556, 564)}) # GW5A-25A need these
+
+wirenames_5ast138c.update({n: f"5A{n}" for n in range(1241, 2041)}) # GW5AST-138C need these
+
+wirenumbers_5ast138c = {v: k for k, v in wirenames_5ast138c.items()}
+
+clknames_5ast138c = {}
+clknames_5ast138c.update({n: f"SPINE{n}" for n in range(32)})
+clknames_5ast138c.update({n: f"LWT{n - 32}" for n in range(32, 40)})
+clknames_5ast138c.update({n: f"LWB{n - 40}" for n in range(40, 48)})
+# Apparently the names of the 8 primary clock wires comprise the quadrant
+# number and the number of the actual clock wire: P34 stands for primary clock
+# #4, 3rd quadrant. The quadrants are numbered as:
+# 2        1         center       3        4
+# 2        1         center       3        4
+# in addition, chips with two quadrants have quadrant numbers 3 and 4, not 1
+# and 2 as you might expect.
+# Wires 6 and 7 are the outputs of the dynamic 4-input MUX, the assumed
+# numbers of these inputs are listed below:
+clknames_5ast138c.update({
+     48: 'P16A', 49: 'P16B', 50: 'P16C', 51: 'P16D',
+     52: 'P17A', 53: 'P17B', 54: 'P17C', 55: 'P17D',
+     56: 'P26A', 57: 'P26B', 58: 'P26C', 59: 'P26D',
+     60: 'P27A', 61: 'P27B', 62: 'P27C', 63: 'P27D',
+     64: 'P36A', 65: 'P36B', 66: 'P36C', 67: 'P36D',
+     68: 'P37A', 69: 'P37B', 70: 'P37C', 71: 'P37D',
+     72: 'P46A', 73: 'P46B', 74: 'P46C', 75: 'P46D',
+     76: 'P47A', 77: 'P47B', 78: 'P47C', 79: 'P47D'
+})
+clknames_5ast138c[80] = 'VSS'
+# each PLL has 4 delay-critical outputs (clkout, clkoutp, clkoutd, clkoutd3),
+# their numbers are listed here, the names indicate the possible location of
+# the PLL (Top Left etc):
+clknames_5ast138c.update({
+    81: 'TLPLL0CLK0', 82: 'TLPLL0CLK1', 83: 'TLPLL0CLK2', 84: 'TLPLL0CLK3',
+    85: 'TLPLL1CLK0', 86: 'TLPLL1CLK1', 87: 'TLPLL1CLK2', 88: 'TLPLL1CLK3',
+    89: 'BLPLL0CLK0', 90: 'BLPLL0CLK1', 91: 'BLPLL0CLK2', 92: 'BLPLL0CLK3',
+    93: 'TRPLL0CLK0', 94: 'TRPLL0CLK1', 95: 'TRPLL0CLK2', 96: 'TRPLL0CLK3',
+    97: 'TRPLL1CLK0', 98: 'TRPLL1CLK1', 99: 'TRPLL1CLK2', 100: 'TRPLL1CLK3',
+    101: 'BRPLL0CLK0', 102: 'BRPLL0CLK1', 103: 'BRPLL0CLK2', 104: 'BRPLL0CLK3',
+})
+
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(105, 131)})
+
+# These are the external clock pins, two on each side
+clknames_5ast138c.update({
+    131: 'PCLKT0', 132: 'PCLKT1', 133: 'PCLKB0', 134: 'PCLKB1',
+    135: 'PCLKL0', 136: 'PCLKL1', 137: 'PCLKR0', 138: 'PCLKR1',
+})
+
+clknames_5ast138c.update({
+    139: 'TRBDCLK0', 140: 'TRBDCLK1', 141: 'TRBDCLK2', 142: 'TRBDCLK3',
+    143: 'TLBDCLK1', 144: 'TLBDCLK2', 145: 'TLBDCLK3', 146: 'TLBDCLK0',
+    147: 'BRBDCLK2', 148: 'BRBDCLK3', 149: 'BRBDCLK0', 150: 'BRBDCLK1',
+    151: 'BLBDCLK3', 152: 'BLBDCLK0', 153: 'BLBDCLK1', 154: 'BLBDCLK2',
+    155: 'TRMDCLK0', 156: 'TLMDCLK0', 157: 'BRMDCLK0', 158: 'BLMDCLK0',
+    159: 'BLMDCLK1', 160: 'BRMDCLK1', 161: 'TLMDCLK1', 162: 'TRMDCLK1',
+})
+
+#clknames_5ast138c[153] = 'VCC'
+
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(163, 237)})
+
+clknames_5ast138c.update({
+    237: 'CBRIDGEOUT_TOP0', 238: 'CBRIDGEOUT_TOP1', 239: 'CBRIDGEOUT_TOP2', 240: 'CBRIDGEOUT_TOP3',
+    241: 'CBRIDGEOUT_TOP4', 242: 'CBRIDGEOUT_TOP5', 243: 'CBRIDGEOUT_TOP6', 244: 'CBRIDGEOUT_TOP7',
+    245: 'CBRIDGEOUT_BOTTOM0', 246: 'CBRIDGEOUT_BOTTOM1', 247: 'CBRIDGEOUT_BOTTOM2', 248: 'CBRIDGEOUT_BOTTOM3',
+    249: 'CBRIDGEOUT_BOTTOM4', 250: 'CBRIDGEOUT_BOTTOM5', 251: 'CBRIDGEOUT_BOTTOM6', 252: 'CBRIDGEOUT_BOTTOM7',
+})
+
+
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(253, 309)})
+
+#clknames_5ast138c.update({n: f"UNK{n}" for n in range(185, 277)})
+clknames_5ast138c[277] = 'VCC'
+#clknames_5ast138c.update({n: f"UNK{n}" for n in range(278, 281)})
+
+clknames_5ast138c.update({291: "GT00", 292: "GT10"})
+
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(309, 570)}) # GW5AST-138C need these
+
+# HCLK->clock network
+# Each HCLK can connect to other HCLKs through two MUXes in the clock system.
+# Here we assign numbers to these MUXes and their inputs - two per HCLK
+clknames_5ast138c.update({
+    1000: 'HCLKMUX0', 1001: 'HCLKMUX1',
+    1002: 'HCLK0_BANK_OUT0', 1003: 'HCLK0_BANK_OUT1',
+    1004: 'HCLK1_BANK_OUT0', 1005: 'HCLK1_BANK_OUT1',
+    1006: 'HCLK2_BANK_OUT0', 1007: 'HCLK2_BANK_OUT1',
+    1008: 'HCLK3_BANK_OUT0', 1009: 'HCLK3_BANK_OUT1',
+})
+
+clknames_5ast138c.update({n: f"LWSPINETL{n - 1001}" for n in range(1001, 1009)})
+clknames_5ast138c.update({n: f"LWSPINETR{n - 1009}" for n in range(1009, 1017)})
+clknames_5ast138c.update({n: f"LWSPINEBL{n - 1017}" for n in range(1017, 1025)})
+clknames_5ast138c.update({n: f"LWSPINEBR{n - 1025}" for n in range(1025, 1033)})
+clknames_5ast138c.update({n: f"LWSPINEB1L{n - 1033}" for n in range(1033, 1041)})
+clknames_5ast138c.update({n: f"LWSPINEB1R{n - 1041}" for n in range(1041, 1049)})
+
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1049, 1225)})
+
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1273, 1289)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1353, 1369)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1433, 1449)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1513, 1529)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1593, 1609)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1673, 1689)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1753, 1769)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1833, 1849)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1913, 1929)}) # GW5AST-138C need these
+clknames_5ast138c.update({n: f"UNK{n}" for n in range(1993, 2009)}) # GW5AST-138C need these
+
+clknumbers_5ast138c = {v: k for k, v in clknames_5ast138c.items()}
+
+# hclk
+hclknames_5ast138c = clknames_5ast138c.copy()
+
+hclknames_5ast138c[0] = 'VSS'
+hclknames_5ast138c[1] = 'VCC'
+hclknames_5ast138c[187] = 'VSS'
+hclknames_5ast138c[188] = 'VCC'
+hclknames_5ast138c[374] = 'VSS'
+hclknames_5ast138c[375] = 'VCC'
+hclknames_5ast138c[561] = 'VSS'
+hclknames_5ast138c[562] = 'VCC'
+
+hclknames_5ast138c.update({n: f"HCLK_UNK{n}" for n in range(2, 701)})
+
+# HCLK->CLK
+hclknames_5ast138c.update({n: f"HCLK_TO_GCLK0{i}" for i, n in enumerate([25, 27, 28, 29])})
+hclknames_5ast138c.update({n: f"HCLK_TO_GCLK1{i}" for i, n in enumerate([212, 214, 215, 216])})
+hclknames_5ast138c.update({n: f"HCLK_TO_GCLK2{i}" for i, n in enumerate([399, 401, 402, 403])})
+hclknames_5ast138c.update({n: f"HCLK_TO_GCLK3{i}" for i, n in enumerate([586, 588, 589, 590])})
+
+# GCLK pins
+hclknames_5ast138c.update({n: f"HCLK_GCLK0{i}" for i, n in enumerate(range(123, 131))})
+hclknames_5ast138c.update({n: f"HCLK_GCLK1{i}" for i, n in enumerate(range(310, 318))})
+hclknames_5ast138c.update({n: f"HCLK_GCLK2{i}" for i, n in enumerate(range(497, 505))})
+hclknames_5ast138c.update({n: f"HCLK_GCLK3{i}" for i, n in enumerate(range(684, 692))})
+
+hclknumbers_5ast138c = {v: k for k, v in hclknames_5ast138c.items()}
+
 # Switcher
 wirenames   = None
 wirenumbers = None
@@ -403,13 +584,20 @@ hclknumbers = None
 
 def select_wires(device):
     global wirenames, clknames, hclknames, wirenumbers, clknumbers, hclknumbers
-    if device in {'GW5A-25A', 'GW5AST-138C'}:
+    if device in {'GW5A-25A'}:
         wirenames   = wirenames_5a25a
         wirenumbers = wirenumbers_5a25a
         clknames    = clknames_5a25a
         clknumbers  = clknumbers_5a25a
         hclknames   = hclknames_5a25a
         hclknumbers = hclknumbers_5a25a
+    elif device in {'GW5AST-138C'}:
+        wirenames   = wirenames_5ast138c
+        wirenumbers = wirenumbers_5ast138c
+        clknames    = clknames_5ast138c
+        clknumbers  = clknumbers_5ast138c
+        hclknames   = hclknames_5ast138c
+        hclknumbers = hclknumbers_5ast138c
     else:
         wirenames   = wirenames_pre5a
         wirenumbers = wirenumbers_pre5a


### PR DESCRIPTION
This chip has the most complex clock system in the entire 5A series: the entire chip is divided into three parts, two of which are full-fledged 4-quadrant clock systems, while the third contains the mechanisms for communication between the first two.

Each of the four quadrant parts is organised not as a matrix, but as a ribbon, where the quadrants are arranged in a row.

Where in previous series (and in other 5A series chips) there was a single backbone wire, now there are three backbones connected to a single clock wire.

There are many ways to switch clock wires (where to get the signal from, where to send it), and at this stage we are implementing a simplified clock circuit: the clock sources are logic->clock gates, the signal is always sent to the central clock bridge and from there it is distributed to the quadrants.

Despite the simplifications, the system does not introduce delays or clock skew—after the gate, the signal propagates exclusively along global wires to all corners of the chip.

We also permit the use of SSRAM and flip-flops in SLICE 3.