### PR TITLE
Improved Handling of SSPI GPIO Overrides for Arora-V. and added .DS_s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ generic/blinky.png
 generic/blinky.posp
 generic/blinky.vm
 .vscode
+.DS_Store

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -3531,8 +3531,13 @@ def place(db, tilemap, bels, cst, args, slice_attrvals, extra_slots):
         elif typ == "PINCFG":
             if args.i2c_as_gpio != ('I2C' in parms):
                 raise Exception(f" i2c_as_gpio has conflicting settings in nexpnr and gowin_pack.")
-            if args.sspi_as_gpio != ('SSPI' in parms):
-                raise Exception(f" sspi_as_gpio has conflicting settings in nexpnr and gowin_pack.")
+            if args.sspi_as_gpio is not None:
+                auto_detected = 'SSPI' in parms
+                if args.sspi_as_gpio != auto_detected:
+                    print(f"Warning: SSPI pin configuration mismatch (flag={args.sspi_as_gpio}, detected={auto_detected}). Proceeding with flag override.")
+                else:
+                    # If the user didn't specify, use the inferred detection
+                    args.sspi_as_gpio = ('SSPI' in parms)
         elif typ.startswith("FLASH"):
             pass
         elif typ.startswith("EMCU"):


### PR DESCRIPTION
# gowin_pack: Allow SSPI/CPU GPIO overrides for GW5A devices

## Description
Currently, gowin_pack raises a hard exception when a user-requested sspi_as_gpio configuration conflicts with the device's chip-database inference. For the GW5A-25A (Arora-V), this is often a false positive, as these pins are frequently required as GPIO for custom board routing (e.g., on the Tang Primer 25K).

This patch:
 1. Converts the hard exception into a descriptive warning.
 2. Respects explicit command-line overrides (args.sspi_as_gpio is not None)
  rather than forcing the database default.
 3. Resolves conflicts where the toolchain implicitly locks pins that the
  user has explicitly requested to use as GPIO.

This fixes builds for the Tang Primer 25K where the clock and configuration pins require manual GPIO assignment. 


