### PR TITLE
dat_parser: support partType-1 .dat files

### DIFF
--- a/apycula/dat_parser.py
+++ b/apycula/dat_parser.py
@@ -35,8 +35,13 @@ class Datfile:
 
         if partType == 0:       # 1/2 Series
             self.compat_dict.update(self.read_something())
-        elif partType == 1:
-            raise Exception(f"PartType {partType} is not supported")
+        elif partType == 1:     # GW1N-2 / GW1N-1P5 family (FNIRSI 2C53T die)
+            # Same base .dat layout as partType 0 (all sections are at fixed absolute
+            # offsets below 0x7b4a8, guarded by asserts that would fire on misalign).
+            # partType 1 only *appends* a ~33 KB extended table at 0x7b4a8 (0x7b4a4
+            # for these files is 538638 B vs 505000 B for partType 0) which we do not
+            # parse yet — base grid/IO/logic parse identically. See docs/02.
+            self.compat_dict.update(self.read_something())
         elif partType == 2:  # 5 Series
             self.gw5aStuff = self.read_5Astuff()
             self.compat_dict.update(self.read_something())


### PR DESCRIPTION
Gowin's `.dat` files carry a `partType` field (offset `0x7b4a4`). `dat_parser`
handles partType 0 (1/2 series) and 2 (5 series) but raises on **partType 1**, the
format used by the GW1N-2 / GW1N-1P5 / GW1N-2B / GW1NR-2 / GW1NZR-2 family.

partType-1 files are byte-identical to partType-0 across the entire fixed-offset
region the parser reads (primitives, grid, portmap, IO) — they only *append* a
~33 KB extended table at `0x7b4a8`. This patch treats partType 1 like partType 0 (all
existing offset asserts pass) and reads the trailing table.

This alone unblocks the whole GW1N-2/1P5 family for downstream device work. It's a
standalone parser fix — no new device required to land it.

Part of #515.
