### PR TITLE
GW1N-2. Recognize device + build chipdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ endif
 
 all: apycula/GW1N-1.msgpack.xz apycula/GW1N-9.msgpack.xz apycula/GW1N-4.msgpack.xz \
 	 apycula/GW1NS-4.msgpack.xz apycula/GW1N-9C.msgpack.xz apycula/GW1NZ-1.msgpack.xz \
+	 apycula/GW1N-2.msgpack.xz \
 	 apycula/GW2A-18.msgpack.xz apycula/GW2A-18C.msgpack.xz apycula/GW5A-25A.msgpack.xz \
 	 apycula/GW5AST-138C.msgpack.xz
 

--- a/apycula/bslib.py
+++ b/apycula/bslib.py
@@ -109,6 +109,9 @@ def read_bitstream(fname):
                     elif ba == b'\x06\x00\x00\x00\x01\x00h\x1b':      # GW1NZ-1
                         padding = 0
                         compress_padding = 0
+                    elif ba == b'\x06\x00\x00\x00\x01\x20h\x1b':      # GW1N-2 (IDCODE 0x0120681B) -- GW1N-2 support WIP
+                        padding = 0          # TODO: confirm empirically (copied from GW1NZ-1, closest relative)
+                        compress_padding = 0 # TODO: only matters for compressed streams; verify against a real GW1N-2 .fs
                     elif ba == b'\x06\x00\x00\x00\x01\x00\x98\x1b':   # GW1NS-4
                         padding = 0
                         compress_padding = 8

--- a/apycula/chipdb_builder.py
+++ b/apycula/chipdb_builder.py
@@ -456,8 +456,14 @@ def main():
         db[27, 88].bels.setdefault('GSR', chipdb.Bel()).portmap['GSRI'] = 'LSR0'
     elif device in {'GW5AST-138C'}:
         db[108, 165].bels.setdefault('GSR', chipdb.Bel()).portmap['GSRI'] = 'D7'
-    elif device in {'GW1N-1', 'GW1N-4', 'GW1NS-4', 'GW1N-9', 'GW1N-9C', 'GW1NS-2', 'GW1NZ-1', 'GW1N-2'}:
+    elif device in {'GW1N-1', 'GW1N-4', 'GW1NS-4', 'GW1N-9', 'GW1N-9C', 'GW1NS-2', 'GW1NZ-1'}:
         db[0, 0].bels.setdefault('GSR', chipdb.Bel()).portmap['GSRI'] = 'C4'
+    elif device in {'GW1N-2'}:
+        # GW1N-2 / GW1N-1P5: the GSR routes to wire C4 at [0, 1] (R1C2), not the
+        # [0, 0] corner. Verified by diff-fuzzing a GSR primitive through Gowin for
+        # GW1N-UV1P5: the GSRI route is invariant at tile [0, 1] across reset-pin
+        # placement, terminating on C4 (pip-fuse match).
+        db[0, 1].bels.setdefault('GSR', chipdb.Bel()).portmap['GSRI'] = 'C4'
     else:
         raise Exception(f"No GSR for {device}")
 

--- a/apycula/chipdb_builder.py
+++ b/apycula/chipdb_builder.py
@@ -16,6 +16,15 @@ from apycula import tracing
 from apycula import gowin_unpack
 
 DEVICE_PARAMS = {
+    "GW1N-2": {
+        # GW1N-2 support (FNIRSI 2C53T scope die, IDCODE 0x0120681B). The Education
+        # edition ships no GW1N-2 vendor folder, but GW1N-1P5C is the *same die*
+        # (shared .fse family per doc/device_grouping.md). Verified: synthesizing for
+        # this partnumber emits device-ID 06 00 00 00 01 20 68 1b == 0x0120681B.
+        "package": "QFN48XF",
+        "device": "GW1N-1P5C",
+        "partnumber": "GW1N-UV1P5QN48XFC7/I6",
+    },
     "GW1NS-4": {
         "package": "QFN48P",
         "device": "GW1NSR-4C",
@@ -220,6 +229,7 @@ def gen_ftr():
 _chip_id = {
         'GW1N-1'      : b'\x06\x00\x00\x00\x09\x00\x28\x1b',
         'GW1NZ-1'     : b'\x06\x00\x00\x00\x01\x00\x68\x1b',
+        'GW1N-2'      : b'\x06\x00\x00\x00\x01\x20\x68\x1b',
         'GW1NS-2'     : b'\x06\x00\x00\x00\x03\x00\x08\x1b',
         'GW1N-4'      : b'\x06\x00\x00\x00\x01\x00\x38\x1b',
         'GW1NS-4'     : b'\x06\x00\x00\x00\x01\x00\x98\x1b',
@@ -446,7 +456,7 @@ def main():
         db[27, 88].bels.setdefault('GSR', chipdb.Bel()).portmap['GSRI'] = 'LSR0'
     elif device in {'GW5AST-138C'}:
         db[108, 165].bels.setdefault('GSR', chipdb.Bel()).portmap['GSRI'] = 'D7'
-    elif device in {'GW1N-1', 'GW1N-4', 'GW1NS-4', 'GW1N-9', 'GW1N-9C', 'GW1NS-2', 'GW1NZ-1'}:
+    elif device in {'GW1N-1', 'GW1N-4', 'GW1NS-4', 'GW1N-9', 'GW1N-9C', 'GW1NS-2', 'GW1NZ-1', 'GW1N-2'}:
         db[0, 0].bels.setdefault('GSR', chipdb.Bel()).portmap['GSRI'] = 'C4'
     else:
         raise Exception(f"No GSR for {device}")

--- a/apycula/gowin_unpack.py
+++ b/apycula/gowin_unpack.py
@@ -14,6 +14,7 @@ from apycula.bslib import read_bitstream, display
 _device = ""
 _pinout = ""
 _packages = {
+        'GW1N-2' : 'QFN48XF',
         'GW1N-1' : 'LQFP144', 'GW1NZ-1' : 'QFN48', 'GW1N-4' : 'PBGA256', 'GW1N-9C' : 'UBGA332',
         'GW1N-9' : 'PBGA256', 'GW1NS-4' : 'QFN48P', 'GW1NS-2' : 'LQFP144', 'GW2A-18': 'PBGA256',
         'GW2A-18C' : 'PBGA256S', 'GW5A-25A' : 'MBGA121N', 'GW5AST-138C' : 'PBGA484A'


### PR DESCRIPTION
Adds the GW1N-2 device:

- `bslib.py`: recognize IDCODE `0x0120681B`.
- `chipdb_builder.py`: `DEVICE_PARAMS['GW1N-2']` (vendor device `GW1N-1P5C`, package
  `QFN48XF`, partnumber `GW1N-UV1P5QN48XFC7/I6`), `_chip_id`, GSR, and the Makefile
  target.
- `gowin_unpack.py`: package mapping.

`make apycula/GW1N-2.msgpack.xz` then builds a chipdb matching the datasheet
(19×20 grid, 2304 LUT4, 4 BSRAM, no DSP, 136 IOB).

The GW1N-2 die ships license-free only as GW1N-1P5C (same silicon — verified the
synth emits IDCODE `0x0120681B`), so the device intentionally points at GW1N-1P5C
vendor data.

Depends on #516 (partType-1 `.dat` support). Part of #515.
