### PR TITLE
Fix HCLK pip fuses.

### DIFF
--- a/.github/workflows/chipdb.yml
+++ b/.github/workflows/chipdb.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build Python package
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools wheel twine
+        pip install --upgrade setuptools wheel twine vcs_versioning
         python setup.py --version
         python setup.py sdist bdist_wheel
         # Validate that the resulting wheel can be executed

--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -4341,8 +4341,13 @@ def route(db, tilemap, pips):
             # XXX consider use set_clock_fuses
             if device not in {'GW5A-25A', 'GW5AST-138C'} and dest in tiledata.clock_pips:
                 bits = tiledata.clock_pips[dest][src]
-            elif dest in {'FCLKA', 'FCLKB'} or set_5a_hclk_wire_fuses(src, dest):
+            elif dest in {'FCLKA', 'FCLKB'}:
                 continue
+            elif device in {'GW5A-25A', 'GW5AST-138C'} and set_5a_hclk_wire_fuses(src, dest):
+                continue
+            elif (row - 1, col - 1) in db.hclk_pips and dest in db.hclk_pips[row - 1, col - 1] and src in db.hclk_pips[row - 1, col - 1][dest]:
+                bits = db.hclk_pips[row - 1, col - 1][dest][src]
+                bits.update(do_hclk_banks(db, row - 1, col - 1, src, dest))
             else:
                 bits = tiledata.pips[dest][src]
                 # check if we have 'not conencted to' situation


### PR DESCRIPTION
Bug fix. Pre-5a chips have all their HCLK PIPs in a single cell, so their numbers can be duplicated. Because of this, using set_5a_hclk_wire_fuses() on earlier chips effectively set all such PIPs across the entire chip, which isn't good.