### PR TITLE
gowin_pack: add multiboot address support

### DIFF
--- a/apycula/gowin_pack.py
+++ b/apycula/gowin_pack.py
@@ -4592,6 +4592,17 @@ def set_slice_fuses(db, tilemap, slice_attrvals):
             for brow, bcol in bits:
                 tile[brow][bcol] = 1
 
+def set_multiboot_address(header, address):
+    if not 0 <= address <= 0xffffffff:
+        raise ValueError('Multiboot address must fit in 32 bits')
+
+    for command in header:
+        if command[0] == 0xd2:
+            command[4:8] = address.to_bytes(4, 'big')
+            return
+
+    raise ValueError('Bitstream header does not contain a multiboot address command')
+
 def main():
     global device
     global pnr
@@ -4618,6 +4629,12 @@ def main():
     parser.add_argument('--reconfign_as_gpio', action = 'store_true')
     parser.add_argument('--cpu_as_gpio', action = 'store_true')
     parser.add_argument('--i2c_as_gpio', action = 'store_true')
+    parser.add_argument(
+        '--multiboot_address',
+        type=lambda value: int(value, 0),
+        default=None,
+        help='SPI flash address of the next bitstream for multiboot'
+    )
     if pil_available:
         parser.add_argument('--png')
 
@@ -4717,6 +4734,9 @@ def main():
         main_map = bitmatrix.transpose(main_map)
 
     header_footer(db, main_map, args.compress)
+
+    if args.multiboot_address is not None:
+        set_multiboot_address(db.cmd_hdr, args.multiboot_address)
 
     if device in {'GW5A-25A', 'GW5AST-138C'} and gw5a_bsrams:
         # In the series preceding GW5A, the data for initialising BSRAM was

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -546,3 +546,27 @@ blinky-pll-runber-synth.json: pll/GW1N-4-dyn.vh blinky-pll.v
 
 %-primer20k-unpacked.v: %-primer20k.fs
 	gowin_unpack -d GW2A-18 -o $@ $^
+
+# ============================================================
+# Multiboot
+.PHONY: tangnano20k-multiboot
+
+tangnano20k-multiboot: \
+	blinky-tangnano20k.json \
+	shift-tangnano20k.json
+	gowin_pack -c -d GW2A-18C \
+	  	--multiboot_address 0x200000 \
+		-o blinky-tangnano20k-multiboot.fs \
+		blinky-tangnano20k.json
+
+	gowin_pack -c -d GW2A-18C \
+	  	--multiboot_address 0x000000 \
+		-o shift-tangnano20k-multiboot.fs \
+		shift-tangnano20k.json
+
+	openFPGALoader -b tangnano20k -f \
+		blinky-tangnano20k-multiboot.fs
+
+	openFPGALoader -b tangnano20k -f \
+		--offset 0x200000 \
+		shift-tangnano20k-multiboot.fs


### PR DESCRIPTION
Adds a `--multiboot_address` option to `gowin_pack` for setting the SPI flash address of the next bitstream.

I needed this functionality for a multiboot setup and decided to add support for it to `gowin_pack`.

The option updates the existing `0xD2` SPI flash address command in the bitstream header.

Hardware tested on a Tang Nano 20K (GW2A-18C):

- Verified that only the `0xD2` command changes when setting a multiboot address.
- Tested with both compressed and uncompressed bitstreams.
- Verified reconfiguration in both directions between bitstreams stored at `0x000000` and `0x200000` using `RECONFIG_N`.